### PR TITLE
Option to hide "Home" sidebar

### DIFF
--- a/chrome/css/main.css
+++ b/chrome/css/main.css
@@ -1,5 +1,5 @@
 html[remove_homepage="true"] ytd-browse[page-subtype="home"],
-html[remove_homepage="true"] a[href="/"],
+html[remove_homepage="true"] ytd-mini-guide-entry-renderer > a[href="/"],
 html[remove_sidebar="true"] #secondary > div.circle,
 html[remove_sidebar="true"] #related,
 html[remove_end_of_video="true"] .html5-endscreen,

--- a/chrome/css/main.css
+++ b/chrome/css/main.css
@@ -1,4 +1,5 @@
 html[remove_homepage="true"] ytd-browse[page-subtype="home"],
+html[remove_homepage="true"] a[href="/"],
 html[remove_sidebar="true"] #secondary > div.circle,
 html[remove_sidebar="true"] #related,
 html[remove_end_of_video="true"] .html5-endscreen,

--- a/chrome/css/main.css
+++ b/chrome/css/main.css
@@ -1,11 +1,11 @@
 html[remove_homepage="true"] ytd-browse[page-subtype="home"],
-html[remove_homepage="true"] ytd-mini-guide-entry-renderer > a[href="/"],
 html[remove_sidebar="true"] #secondary > div.circle,
 html[remove_sidebar="true"] #related,
 html[remove_end_of_video="true"] .html5-endscreen,
 
 html[remove_info_cards="true"] .ytp-ce-element.ytp-ce-element,
 
+html[remove_home_sidebar="true"] ytd-mini-guide-entry-renderer > a[href="/"],
 html[remove_trending="true"] a[href="/feed/trending"],
 html[remove_trending="true"] a[href="/feed/explore"],
 

--- a/chrome/js/main.js
+++ b/chrome/js/main.js
@@ -4,6 +4,7 @@ const DEFAULT_SETTINGS = {
   "remove_sidebar": true,
   "remove_end_of_video": true,
   "remove_info_cards": false,
+  "remove_home_sidebar": false,
   "remove_trending": false,
   "remove_comments": false,
   "remove_chat": false,

--- a/chrome/js/options.js
+++ b/chrome/js/options.js
@@ -4,6 +4,7 @@ const DEFAULT_SETTINGS = {
   "remove_sidebar": true,
   "remove_end_of_video": true,
   "remove_info_cards": false,
+  "remove_home_sidebar": false,
   "remove_trending": false,
   "remove_comments": false,
   "remove_chat": false,

--- a/chrome/options.html
+++ b/chrome/options.html
@@ -39,6 +39,12 @@
       </div>
 
       <div>
+        <input type="checkbox" id="remove_home_sidebar" name="feature"
+               value="remove_home_sidebar" unchecked />
+        <label for="remove_home_sidebar">Link to Home Page</label>
+      </div>
+
+      <div>
           <input type="checkbox" id="remove_trending" name="feature"
                  value="remove_trending" unchecked />
           <label for="remove_trending">Link to Explore Page</label>

--- a/firefox/css/main.css
+++ b/firefox/css/main.css
@@ -1,4 +1,5 @@
 html[global_enable="true"][remove_homepage="true"] ytd-browse[page-subtype="home"],
+html[global_enable="true"][remove_homepage="true"] a[href="/"],
 html[global_enable="true"][remove_sidebar="true"] #secondary > div.circle,
 html[global_enable="true"][remove_sidebar="true"] #related,
 html[global_enable="true"][remove_end_of_video="true"] .html5-endscreen,

--- a/firefox/css/main.css
+++ b/firefox/css/main.css
@@ -1,5 +1,5 @@
 html[global_enable="true"][remove_homepage="true"] ytd-browse[page-subtype="home"],
-html[global_enable="true"][remove_homepage="true"] a[href="/"],
+html[global_enable="true"][remove_homepage="true"] ytd-mini-guide-entry-renderer > a[href="/"],
 html[global_enable="true"][remove_sidebar="true"] #secondary > div.circle,
 html[global_enable="true"][remove_sidebar="true"] #related,
 html[global_enable="true"][remove_end_of_video="true"] .html5-endscreen,

--- a/firefox/css/main.css
+++ b/firefox/css/main.css
@@ -1,11 +1,11 @@
 html[global_enable="true"][remove_homepage="true"] ytd-browse[page-subtype="home"],
-html[global_enable="true"][remove_homepage="true"] ytd-mini-guide-entry-renderer > a[href="/"],
 html[global_enable="true"][remove_sidebar="true"] #secondary > div.circle,
 html[global_enable="true"][remove_sidebar="true"] #related,
 html[global_enable="true"][remove_end_of_video="true"] .html5-endscreen,
 
 html[global_enable="true"][remove_info_cards="true"] .ytp-ce-element.ytp-ce-element,
 
+html[global_enable="true"][remove_home_sidebar="true"] ytd-mini-guide-entry-renderer > a[href="/"],
 html[global_enable="true"][remove_trending="true"] a[href="/feed/trending"],
 html[global_enable="true"][remove_trending="true"] a[href="/feed/explore"],
 

--- a/firefox/js/main.js
+++ b/firefox/js/main.js
@@ -5,6 +5,7 @@ const SETTINGS_LIST = {
   "remove_sidebar":       { default: true,  eventType: 'change' },
   "remove_end_of_video":  { default: true,  eventType: 'change' },
   "remove_info_cards":    { default: false, eventType: 'change' },
+  "remove_home_sidebar":  { default: false, eventType: 'change'  },
   "remove_trending":      { default: false, eventType: 'change' },
   "remove_comments":      { default: false, eventType: 'change' },
   "remove_chat":          { default: false, eventType: 'change' },

--- a/firefox/js/options.js
+++ b/firefox/js/options.js
@@ -5,6 +5,7 @@ const SETTINGS_LIST = {
   "remove_sidebar":       { default: true,  eventType: 'click' },
   "remove_end_of_video":  { default: true,  eventType: 'click' },
   "remove_info_cards":    { default: false, eventType: 'click' },
+  "remove_home_sidebar":  { default: false, eventType: 'click' },
   "remove_trending":      { default: false, eventType: 'click' },
   "remove_comments":      { default: false, eventType: 'click' },
   "remove_chat":          { default: false, eventType: 'click' },

--- a/firefox/options.html
+++ b/firefox/options.html
@@ -40,6 +40,10 @@
       <fieldset>
         <legend>More removal options</legend>
 
+        <div class="remove_home_sidebar">
+          <div class="option_name_container"><a class="active">🚫</a><a class="inactive">🟢</a> Link to home page</div>
+        </div>
+
         <div class="remove_trending">
             <div class="option_name_container"><a class="active">🚫</a><a class="inactive">🟢</a> Link to explore page</div>
         </div>


### PR DESCRIPTION
Hello! Thank you for taking your time to create this extension.

I have an idea to add an option to hide "Home" sidebar, because when I enable most of the feature I find the "Home" sidebar rather annoying 😄. 

I made changes for both Chrome and Firefox extension, but I only tested it in Chrome.

This is how the website would look like when the option is checked : 

![image](https://user-images.githubusercontent.com/57693622/144717831-83045987-5c7b-485c-a1b2-d6c3d5ac7c86.png)

The option would look like this (the "Link to Home Page" one) :

![image](https://user-images.githubusercontent.com/57693622/144718363-157200c8-c0ae-42b0-9672-d88701cf338e.png)

Thank you! Would appreciate your feedback on this.