### PR TITLE
Add option to hide video likes

### DIFF
--- a/src/content-script/main.css
+++ b/src/content-script/main.css
@@ -60,6 +60,7 @@ html[global_enable="true"][remove_info_cards="true"] .ytp-ce-element.ytp-ce-elem
 html[global_enable="true"][remove_vid_description="true"] ytd-watch-metadata #description,
 html[global_enable="true"][remove_menu_buttons="true"] #menu-container,
 html[global_enable="true"][remove_menu_buttons="true"] #actions,
+html[global_enable="true"][remove_video_likes="true"] ytd-toggle-button-renderer > yt-button-shape > button > div.yt-spec-button-shape-next__button-text-content,
 html[global_enable="true"][remove_embedded_more_videos="true"] div.ytp-pause-overlay,
 html[global_enable="true"][remove_overlay_suggestions="true"] .ytp-cards-teaser,
 html[global_enable="true"][remove_overlay_suggestions="true"] button.ytp-button.ytp-cards-button,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "description": "Spend less time on YouTube. Customize YouTube's user interface to be less engaging.",
   "homepage_url": "https://github.com/lawrencehook/remove-youtube-suggestions",
   "manifest_version": 2,
-  "version": "4.3.49",
+  "version": "4.3.50",
 
   "icons": {
     "16": "/images/16.png",

--- a/src/shared/main.js
+++ b/src/shared/main.js
@@ -248,6 +248,11 @@ const SECTIONS = [
         defaultValue: false
       },
       {
+        name: "Hide the likes",
+        id: "remove_video_likes",
+        defaultValue: false
+      },
+      {
         name: "Hide the description",
         id: "remove_vid_description",
         defaultValue: false


### PR DESCRIPTION
There's already an option that removes all the menu buttons, but that's too aggressive based on my usage.
And some of that buttons are useful, like the share, transcript, thanks.

I think this option should be greyed out / disabled while the option that disables all menu buttons is enabled, but I don't have much time to dig in and I'm a beginner, sorry.

Maybe a better approach would be to provide options for each menu button.

Just a random user who has been using your extension for a while. Thank you for your work! 🙂 