### PR TITLE
Add: allow power button to be active even when schedule is on

### DIFF
--- a/src/options/header.css
+++ b/src/options/header.css
@@ -79,14 +79,14 @@ html[dark_mode='false'] #header-light { display: none }
   visibility: hidden;
   transition: opacity 0.3s ease, visibility 0.3s ease;
 }
-html[schedule='true'] #power-icon,
-html[schedule='true'] #power-icon svg {
+html[schedule='true'][power_btn_active_during_schedule='false'] #power-icon,
+html[schedule='true'][power_btn_active_during_schedule='false'] #power-icon svg {
   cursor: default;
 }
-html[schedule='true'] #power-icon:active {
+html[schedule='true'][power_btn_active_during_schedule='false'] #power-icon:active {
   pointer-events: none;
 }
-html[schedule='true'] #power-icon:hover #power-pop-up {
+html[schedule='true'][power_btn_active_during_schedule='false'] #power-icon:hover #power-pop-up {
   opacity: 1;
   visibility: visible;
 }

--- a/src/shared/main.js
+++ b/src/shared/main.js
@@ -578,7 +578,12 @@ const SECTIONS = [
           }
         }
       },
-    ]
+      {
+        name: "Enable power button during schedule",
+        id: "power_btn_active_during_schedule",
+        defaultValue: false,
+      },
+    ],
   },
 ];
 


### PR DESCRIPTION
Fixes #131

Description:
- This PR adds an option to enable the power button even when the schedule is active. 

@lawrencehook Let me know if you need me to change the labels etc.