### PR TITLE
Fix: disable extension on YouTube Music (closes #152)

### DIFF
--- a/src/chrome_manifest.json
+++ b/src/chrome_manifest.json
@@ -26,7 +26,9 @@
       ],
       "css": ["/content-script/main.css"],
       "all_frames": true,
-      "matches": ["*://*.youtube.com/*"],
+      "matches": [
+        "*://www.youtube.com/*",
+        "*://m.youtube.com/*"],
       "run_at": "document_start"
     }
   ],
@@ -50,6 +52,7 @@
     "storage"
   ],
   "host_permissions": [
-    "*://*.youtube.com/*"
+    "*://www.youtube.com/*",
+    "*://m.youtube.com/*"
   ]
 }

--- a/src/firefox_manifest.json
+++ b/src/firefox_manifest.json
@@ -29,7 +29,9 @@
       ],
       "css": ["/content-script/main.css"],
       "all_frames": true,
-      "matches": ["*://*.youtube.com/*"],
+      "matches": [
+        "*://www.youtube.com/*",
+        "*://m.youtube.com/*"],
       "run_at": "document_start"
     }
   ],
@@ -51,6 +53,7 @@
   },
   "permissions": [
     "storage",
-    "*://*.youtube.com/*"
+    "*://www.youtube.com/*",
+    "*://m.youtube.com/*"
   ]
 }


### PR DESCRIPTION
This PR fixes Issue #152 by restricting the extension's content scripts and host permissions to only www.youtube.com and m.youtube.com.

Previously, the extension also ran on music.youtube.com, hiding tracks on playlist pages. This change prevents that.

Closes #152.