### PR TITLE
fix(sidebar): correct mapping of sidebar section

### DIFF
--- a/src/content-script/main.css
+++ b/src/content-script/main.css
@@ -43,12 +43,12 @@ html[global_enable="true"][remove_shorts_link="true"] ytd-mini-guide-entry-rende
 html[global_enable="true"][remove_subscriptions_link="true"] a[href="/feed/subscriptions"],
 
 /* Left Bar Navigation Sections */
-html[global_enable="true"][remove_quick_links_section="true"] ytd-guide-collapsible-section-entry-renderer,
-html[global_enable="true"][remove_sub_section="true"]      ytd-guide-section-renderer.style-scope:nth-child(2),
-html[global_enable="true"][remove_explore_section="true"]  ytd-guide-section-renderer.style-scope:nth-child(3),
-html[global_enable="true"][remove_more_section="true"]     ytd-guide-section-renderer.style-scope:nth-child(4),
-html[global_enable="true"][remove_settings_section="true"] ytd-guide-section-renderer.style-scope:nth-child(5),
-html[global_enable="true"][remove_footer_section="true"]   #guide-renderer > div#footer,
+html[global_enable="true"][remove_sub_section="true"]      		ytd-guide-section-renderer.style-scope:nth-of-type(2),
+html[global_enable="true"][remove_quick_links_section="true"] 	ytd-guide-section-renderer.style-scope:nth-of-type(3),
+html[global_enable="true"][remove_explore_section="true"]  		ytd-guide-section-renderer.style-scope:nth-of-type(4),
+html[global_enable="true"][remove_more_section="true"]     		ytd-guide-section-renderer.style-scope:nth-of-type(5),
+html[global_enable="true"][remove_settings_section="true"] 		ytd-guide-section-renderer.style-scope:nth-of-type(6),
+html[global_enable="true"][remove_footer_section="true"]   		#guide-renderer > div#footer,
 
 
 /* Homepage */

--- a/src/shared/main.js
+++ b/src/shared/main.js
@@ -175,16 +175,16 @@ const SECTIONS = [
     tags: "Left Navbar",
     options: [
       {
-        name: "Hide section - You/Library",
-        id: "remove_quick_links_section",
-        defaultValue: false,
-        effects: { true: { only_show_playlists: false }}
-      },
-      {
         name: "Hide section - Subscriptions",
         id: "remove_sub_section",
         defaultValue: false,
         effects: { false: { only_show_playlists: false }}
+      },
+      {
+        name: "Hide section - You/Library",
+        id: "remove_quick_links_section",
+        defaultValue: false,
+        effects: { true: { only_show_playlists: false }}
       },
       {
         name: "Hide section - Explore",


### PR DESCRIPTION
Youtube changed the structure of the sidebar, this caused several toggle target issues in the extension.
-> Hiding you/library removed the section contents but left a small empty container. 
-> Hiding other sections hid the wrong ones. Explore hid you/library completely, more from youtube hid explore, settings hid more from youtube. And couldn't hide settings at all.

This commit updates the CSS to match the new DOM structure.

-> Replaced nth-child with nth-of type
-> Realigned indexes to match new structure.
  - `remove_sub_section` targets the 2nd section (Subscriptions)
  - `remove_quick_links_section` targets the 3rd section (You / Library)
  - `remove_explore_section` targets the 4th section (Explore)
  - `remove_more_section` targets the 5th section (More from YouTube)
  - `remove_settings_section` targets the 6th section (Settings)
  - `remove_footer_section` still hides `#guide-renderer > #footer` -> Modified the order of the buttons in src/content-script/main.css to match the order in the sidebar.

Resolves: #185 and #182