### PR TITLE
Port dev.sh + release CI from curb; make redirects free

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install web-ext
+        run: npm install -g web-ext
+
+      - name: Build Firefox zip
+        run: ./firefox.sh
+
+      - name: Build Chrome zip
+        run: ./chrome.sh
+
+      - name: Stage release assets
+        run: |
+          mkdir -p dist
+          cp src/web-ext-artifacts/*.zip "dist/rys-firefox-${GITHUB_REF_NAME}.zip"
+          cp extension.zip "dist/rys-chrome-${GITHUB_REF_NAME}.zip"
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.zip
+          fail_on_unmatched_files: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ extension.zip
 manifest.json
 _scratch/
 node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -32,11 +32,15 @@ This project is 100% open source. Created and maintained by me, [Lawrence Hook](
 
 Have a feature request or found a bug? Feel free to create a Github issue, submit a PR, or contact me at lawrencehook@gmail.com.
 
-The following commands will set up a Firefox dev environment.
+`./dev.sh <firefox|chrome>` lets both browsers run side-by-side without clobbering each other's `manifest.json`.
 
 ```bash
 git clone https://github.com/lawrencehook/remove-youtube-suggestions.git
-cd remove-youtube-suggestions/src
+cd remove-youtube-suggestions
 npm install --global web-ext
-web-ext run
+
+./dev.sh firefox     # writes src/manifest.json, launches web-ext run
+./dev.sh chrome      # builds dist/chrome/ — load as unpacked in chrome://extensions
 ```
+
+Firefox runs from `src/` directly (web-ext doesn't reliably load scripts through directory symlinks). Chrome runs from `dist/chrome/`, a tree of symlinks back into `src/` with `chrome_manifest.json` copied in. Edits in `src/` propagate live to both.

--- a/README.md
+++ b/README.md
@@ -32,15 +32,11 @@ This project is 100% open source. Created and maintained by me, [Lawrence Hook](
 
 Have a feature request or found a bug? Feel free to create a Github issue, submit a PR, or contact me at lawrencehook@gmail.com.
 
-`./dev.sh <firefox|chrome>` lets both browsers run side-by-side without clobbering each other's `manifest.json`.
-
 ```bash
 git clone https://github.com/lawrencehook/remove-youtube-suggestions.git
 cd remove-youtube-suggestions
 npm install --global web-ext
 
-./dev.sh firefox     # writes src/manifest.json, launches web-ext run
+./dev.sh firefox     # opens Firefox with the extension loaded
 ./dev.sh chrome      # builds dist/chrome/ — load as unpacked in chrome://extensions
 ```
-
-Firefox runs from `src/` directly (web-ext doesn't reliably load scripts through directory symlinks). Chrome runs from `dist/chrome/`, a tree of symlinks back into `src/` with `chrome_manifest.json` copied in. Edits in `src/` propagate live to both.

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Local dev launcher. Two strategies, one per browser:
+#
+#   firefox  Run web-ext from src/ directly. web-ext / Firefox don't
+#            reliably load scripts through directory symlinks, so the
+#            dist/-symlink trick we use for Chrome doesn't work here.
+#            We just drop the firefox manifest into src/ and run.
+#
+#   chrome   Build dist/chrome/ as a tree of symlinks back into src/,
+#            with chrome_manifest.json copied in as manifest.json.
+#            Load that as an unpacked extension via chrome://extensions.
+#
+# Both can run side-by-side: dist/chrome/manifest.json is a real copy
+# in its own directory, so writing src/manifest.json for Firefox doesn't
+# affect Chrome.
+
+set -euo pipefail
+
+browser="${1:-}"
+case "$browser" in
+  firefox|chrome) ;;
+  *) echo "Usage: $0 <firefox|chrome>" >&2; exit 1 ;;
+esac
+
+repo="$(cd "$(dirname "$0")" && pwd)"
+src="$repo/src"
+
+case "$browser" in
+  firefox)
+    cd "$src"
+    cp firefox_manifest.json manifest.json
+    trap 'rm -f "$src/manifest.json"' EXIT
+    echo "Launching: web-ext run from $src"
+    exec web-ext run
+    ;;
+
+  chrome)
+    dst="$repo/dist/chrome"
+    mkdir -p "$dst"
+
+    for path in "$src"/* "$src"/.[!.]*; do
+      [ -e "$path" ] || continue
+      name=$(basename "$path")
+      case "$name" in
+        *_manifest.json|manifest.json|web-ext-artifacts) continue ;;
+      esac
+      ln -snf "$path" "$dst/$name"
+    done
+
+    cp "$src/chrome_manifest.json" "$dst/manifest.json"
+    echo "Ready: $dst"
+    echo "In chrome://extensions, enable Developer mode and 'Load unpacked' → $dst"
+    ;;
+esac

--- a/dev.sh
+++ b/dev.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 # Local dev launcher. Two strategies, one per browser:
 #
-#   firefox  Run web-ext from src/ directly. web-ext / Firefox don't
-#            reliably load scripts through directory symlinks, so the
-#            dist/-symlink trick we use for Chrome doesn't work here.
-#            We just drop the firefox manifest into src/ and run.
+#   firefox  Run web-ext from src/ directly. Drops firefox_manifest.json
+#            in as manifest.json and launches a temp Firefox profile.
 #
-#   chrome   Build dist/chrome/ as a tree of symlinks back into src/,
-#            with chrome_manifest.json copied in as manifest.json.
-#            Load that as an unpacked extension via chrome://extensions.
+#   chrome   Sync src/ into dist/chrome/ as real files (rsync), with
+#            chrome_manifest.json copied in as manifest.json. Load as
+#            an unpacked extension via chrome://extensions.
 #
-# Both can run side-by-side: dist/chrome/manifest.json is a real copy
-# in its own directory, so writing src/manifest.json for Firefox doesn't
-# affect Chrome.
+#            We don't symlink — Chrome's content-script loader silently
+#            rejects scripts whose realpath is outside the extension
+#            directory, so the popup loads but content scripts don't fire.
+#            Re-run this script and click "reload" in chrome://extensions
+#            after editing src/.
 
 set -euo pipefail
 
@@ -38,14 +38,11 @@ case "$browser" in
     dst="$repo/dist/chrome"
     mkdir -p "$dst"
 
-    for path in "$src"/* "$src"/.[!.]*; do
-      [ -e "$path" ] || continue
-      name=$(basename "$path")
-      case "$name" in
-        *_manifest.json|manifest.json|web-ext-artifacts) continue ;;
-      esac
-      ln -snf "$path" "$dst/$name"
-    done
+    rsync -a --delete \
+      --exclude='*_manifest.json' \
+      --exclude='manifest.json' \
+      --exclude='web-ext-artifacts' \
+      "$src/" "$dst/"
 
     cp "$src/chrome_manifest.json" "$dst/manifest.json"
     echo "Ready: $dst"

--- a/src/content-script/main.js
+++ b/src/content-script/main.js
@@ -7,7 +7,7 @@ const REDIRECT_URLS = {
   "redirect_off":        false,
   "redirect_to_subs":    'https://www.youtube.com/feed/subscriptions',
   "redirect_to_wl":      'https://www.youtube.com/playlist/?list=WL',
-  "redirect_to_library": 'https://www.youtube.com/feed/library',
+  "redirect_to_library": 'https://www.youtube.com/feed/you',
 };
 
 

--- a/src/shared/main.js
+++ b/src/shared/main.js
@@ -571,7 +571,6 @@ const SECTIONS = [
             redirect_off: true
           }
         },
-        premium: true,
       },
       {
         name: "Redirect home to Watch Later",
@@ -587,7 +586,6 @@ const SECTIONS = [
             redirect_off: true
           }
         },
-        premium: true,
       },
       {
         name: "Redirect home to Library",
@@ -603,14 +601,12 @@ const SECTIONS = [
             redirect_off: true
           }
         },
-        premium: true,
       },
       {
         name: "Do not redirect home",
         id: "redirect_off",
         defaultValue: false,
         display: false,
-        premium: true,
       },
     ]
   },


### PR DESCRIPTION
## Summary

Four changes:

- **`dev.sh <firefox|chrome>`**: launches Firefox via `web-ext` from `src/`, and rsyncs `src/` into `dist/chrome/` for Chrome with `chrome_manifest.json` copied in as `manifest.json`. Re-run after edits and click reload in `chrome://extensions`.
- **`.github/workflows/release.yml`**: on tag push (`v*`), CI builds Chrome + Firefox zips and attaches them to a GitHub Release. Replaces the manual `extension.zip` workflow. The `released` branch becomes obsolete — leaving it for now, eventual delete.
- **Redirect features now free**: drops `premium: true` from `redirect_to_subs`, `redirect_to_wl`, `redirect_to_library`, and `redirect_off`. These are advertised on the store listings so gating them behind Premium felt off.
- **Fixes #123**: redirect-to-Library was pointing at `/feed/library`; YouTube renamed the section to "You" and moved it to `/feed/you`.

## Notes
- First attempt at the Chrome dev tree used symlinks (matching the curb extension's setup). Symlinks worked for the popup but Chrome's content-script loader silently rejected scripts whose realpath was outside the extension dir, so YouTube changes never applied. Switched to rsync — trade-off is no live edits, but matches the prior manual workflow.

## Test plan
- [x] `npm test` in `tests/` and `server/`: all pass, matches baseline
- [x] `./dev.sh chrome` builds `dist/chrome/` as real files, loads in Chrome, content scripts fire on YouTube
- [x] Redirect-home toggles work for signed-out users
- [x] `redirect_to_library` lands on `/feed/you`
- [ ] `./dev.sh firefox` smoke test (optional)
- [ ] Tag a `v*` to dry-run release.yml (optional — happens naturally on next release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
