### PR TITLE
Tidy: drop two pieces of dead code

### DIFF
--- a/server/src/routes/checkout.js
+++ b/server/src/routes/checkout.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const { requireAuth } = require('../services/jwt');
-const { createCheckoutSession, createBillingPortalSession } = require('../services/stripe');
+const { createCheckoutSession } = require('../services/stripe');
 const { renderPage } = require('../templates');
 
 const router = express.Router();

--- a/src/background/events.js
+++ b/src/background/events.js
@@ -3,8 +3,6 @@ if (typeof browser === 'undefined') {
   browser = typeof chrome !== 'undefined' ? chrome : null;
 }
 
-// browser.runtime.openOptionsPage();
-
 const uninstallUrl = "http://lawrencehook.com/rys/👋";
 browser.runtime.setUninstallURL(uninstallUrl);
 


### PR DESCRIPTION
## Summary
Two pieces of dead code, no behavior change.

- `server/src/routes/checkout.js:3` — drop unused `createBillingPortalSession` from the import. The portal logic is in `routes/billing.js`; checkout never called it.
- `src/background/events.js` — remove the stale commented-out `// browser.runtime.openOptionsPage();` line.

The survey turned up other candidates (stale comment near annotations toggle, duplicate-looking TODOs in utils.js, bare `console.log(error)` calls, the empty `BANNERS = []` array, a perceived issue with `timeLoop` ID capture). On verification each one had a reason to stay (WHY-comment, distinct location markers, broader TODO already tracked, live infrastructure with zero current entries, agent misread). Notes in the conversation that produced this PR.

## Test plan
- [x] `npm test` in `tests/`: 168/170 pass (2 pre-existing todos), matches baseline
- [x] `npm test` in `server/`: 67/67 pass, matches baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
