### PR TITLE
Tidy: convert tab-indented files to 4-space

### DIFF
--- a/src/shared/analytics.js
+++ b/src/shared/analytics.js
@@ -4,10 +4,10 @@ for(h=0;h<i.length;h++)g(a,i[h]);var j="set set_once union unset remove delete".
 mixpanel.init('44d2dff3b4d141679640b297d31d5093');
 
 function recordEvent(name, props={}) {
-	const logEnabled = document.documentElement.getAttribute('log_enabled') || 'false';
+    const logEnabled = document.documentElement.getAttribute('log_enabled') || 'false';
 
-	if (logEnabled !== 'true') return;
+    if (logEnabled !== 'true') return;
 
-	props.extension_version = browser.runtime.getManifest().version;
-	mixpanel.track(name, props);
+    props.extension_version = browser.runtime.getManifest().version;
+    mixpanel.track(name, props);
 }

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -14,144 +14,144 @@ const subsRegex        = new RegExp(/\/feed\/subscriptions$/, 'i');
 
 /* Scheduling */
 function timeIsValid(times) {
-	const timeRegex = /^([1-9]|1[012]):[0-5][0-9](a|p)-([1-9]|1[012]):[0-5][0-9](a|p)$/i;
-	return times.split(',').every(time => {
-		return timeRegex.test(time.trim());
-	});
+    const timeRegex = /^([1-9]|1[012]):[0-5][0-9](a|p)-([1-9]|1[012]):[0-5][0-9](a|p)$/i;
+    return times.split(',').every(time => {
+        return timeRegex.test(time.trim());
+    });
 
-	// TODO: Check that the start time is before the end time.
+    // TODO: Check that the start time is before the end time.
 }
 
 
 const DAYS = ['su','mo','tu','we','th','fr','sa'];
 function checkSchedule(times, days, now=new Date()) {
-	if (!times || !days) return false;
+    if (!times || !days) return false;
 
-	const currDay = DAYS[now.getDay()];
-	const daysArray = days.split(',').map(d => d.toLowerCase().trim());
+    const currDay = DAYS[now.getDay()];
+    const daysArray = days.split(',').map(d => d.toLowerCase().trim());
 
-	if (!daysArray.includes(currDay)) return false;
+    if (!daysArray.includes(currDay)) return false;
 
-	const timesArray = times.split(',').map(t => t.toLowerCase().trim());
-	const matchFound = timesArray.some(time => {
-		const [ startString, endString ] = time.split('-');
-		const startTime = parseScheduleTime(startString.trim(), now);
+    const timesArray = times.split(',').map(t => t.toLowerCase().trim());
+    const matchFound = timesArray.some(time => {
+        const [ startString, endString ] = time.split('-');
+        const startTime = parseScheduleTime(startString.trim(), now);
 
-		// TODO -> force endTime to come after startTime
-		const endTime = parseScheduleTime(endString.trim(), now);
+        // TODO -> force endTime to come after startTime
+        const endTime = parseScheduleTime(endString.trim(), now);
 
-		return now > startTime && now < endTime;
-	});
+        return now > startTime && now < endTime;
+    });
 
-	return matchFound;
+    return matchFound;
 }
 
 
 function parseScheduleTime(time, now) {
-	if (!time || !now) return;
+    if (!time || !now) return;
 
-	const period = time.slice(-1);
-	const [ hours, minutes ] = time.slice(0, -1).split(':');
+    const period = time.slice(-1);
+    const [ hours, minutes ] = time.slice(0, -1).split(':');
 
-	const hoursNum = Number(hours);
-	let trueHours;
-	if (hoursNum === 12 && period === 'a') {
-		trueHours = 0;
-	} else if (hoursNum === 12 && period === 'p') {
-		trueHours = 12;
-	} else if (period === 'p') {
-	 trueHours = hoursNum + 12;
-	} else {
-		trueHours = hoursNum;
-	}
+    const hoursNum = Number(hours);
+    let trueHours;
+    if (hoursNum === 12 && period === 'a') {
+        trueHours = 0;
+    } else if (hoursNum === 12 && period === 'p') {
+        trueHours = 12;
+    } else if (period === 'p') {
+        trueHours = hoursNum + 12;
+    } else {
+        trueHours = hoursNum;
+    }
 
-	const timeInDay = new Date(now).setHours(trueHours, minutes, 0, 0);
-	return timeInDay;
+    const timeInDay = new Date(now).setHours(trueHours, minutes, 0, 0);
+    return timeInDay;
 }
 
 
 function nextScheduleChange(times, days) {
-	if (!times || !days) return;
+    if (!times || !days) return;
 
-	const current = checkSchedule(times, days);
-	const MIN_IN_WEEK = 10_080;
-	let testDate = new Date();
-	testDate.setSeconds(0);
-	let next = checkSchedule(times, days, testDate);
-	let i = 0;
-	while (current === next && i < MIN_IN_WEEK) {
-		i += 1;
-		testDate = new Date(testDate.getTime() + 60_000);
-		next = checkSchedule(times, days, testDate);
-	}
+    const current = checkSchedule(times, days);
+    const MIN_IN_WEEK = 10_080;
+    let testDate = new Date();
+    testDate.setSeconds(0);
+    let next = checkSchedule(times, days, testDate);
+    let i = 0;
+    while (current === next && i < MIN_IN_WEEK) {
+        i += 1;
+        testDate = new Date(testDate.getTime() + 60_000);
+        next = checkSchedule(times, days, testDate);
+    }
 
-	if (i >= MIN_IN_WEEK) return;
+    if (i >= MIN_IN_WEEK) return;
 
-	return testDate;
+    return testDate;
 }
 
 
 function formatDateMessage(date) {
-	if (!date) return 'unknown date';
-	return date.toLocaleDateString('en-us', {
-		weekday:"long",
-		month:"long",
-		hour12: true,
-		day:"numeric",
-		hour: "numeric",
-		minute: "numeric",
-	});
+    if (!date) return 'unknown date';
+    return date.toLocaleDateString('en-us', {
+        weekday:"long",
+        month:"long",
+        hour12: true,
+        day:"numeric",
+        hour: "numeric",
+        minute: "numeric",
+    });
 }
 
 
 function formatDateMessageShort(date) {
-	if (!date) return 'unknown date';
-	return date.toLocaleDateString('en-us', {
-		hour: "numeric",
-		minute: "numeric",
-	}).match(/[0-9]{1,2}:[0-9]{1,2}.*/)[0].toLowerCase();
+    if (!date) return 'unknown date';
+    return date.toLocaleDateString('en-us', {
+        hour: "numeric",
+        minute: "numeric",
+    }).match(/[0-9]{1,2}:[0-9]{1,2}.*/)[0].toLowerCase();
 }
 
 
 function parseTimeRemaining(ms) {
-	const seconds = Math.floor((ms / (1000)) % 60);
-	const minutes = Math.floor((ms / (60 * 1000)) % 60);
-	const hours = Math.floor((ms / (60 * 60 * 1000)) % 24);
-	const days = Math.floor(ms / (60 * 60 * 24 * 1000) % 7);
+    const seconds = Math.floor((ms / (1000)) % 60);
+    const minutes = Math.floor((ms / (60 * 1000)) % 60);
+    const hours = Math.floor((ms / (60 * 60 * 1000)) % 24);
+    const days = Math.floor(ms / (60 * 60 * 24 * 1000) % 7);
 
-	return { days, hours, minutes, seconds };
+    return { days, hours, minutes, seconds };
 }
 
 
 function hydrateDropdown(
-	root,
-	dropdown,
-	show = d => d.toggleAttribute('hidden', false),
-	hide = d => d.toggleAttribute('hidden', true)
+    root,
+    dropdown,
+    show = d => d.toggleAttribute('hidden', false),
+    hide = d => d.toggleAttribute('hidden', true)
 ) {
 
-	function clickListener(e) {
-	  show(dropdown);
-	  root.removeEventListener('click', clickListener);
-	  const { right, bottom } = root.getBoundingClientRect();
-	  const { width } = dropdown.getBoundingClientRect();
-	  dropdown.style.left = (right - width) + 'px';
-	  dropdown.style.top = (5 + bottom) + 'px';
-	  function hide1(e) {
-	    document.removeEventListener('mousedown', hide1);
-	    function hide2(e) {
-	      document.removeEventListener('mousedown', hide1);
-	      document.removeEventListener('mouseup', hide2);
-	      setTimeout(() => {
-	        hide(dropdown);
-	        root.addEventListener('click', clickListener);
-	      }, 50);
-	    }
-	    document.addEventListener('mouseup', hide2);
-	  };
-	  document.addEventListener('mousedown', hide1);
-	}
-	root.addEventListener('click', clickListener);
+    function clickListener(e) {
+      show(dropdown);
+      root.removeEventListener('click', clickListener);
+      const { right, bottom } = root.getBoundingClientRect();
+      const { width } = dropdown.getBoundingClientRect();
+      dropdown.style.left = (right - width) + 'px';
+      dropdown.style.top = (5 + bottom) + 'px';
+      function hide1(e) {
+        document.removeEventListener('mousedown', hide1);
+        function hide2(e) {
+          document.removeEventListener('mousedown', hide1);
+          document.removeEventListener('mouseup', hide2);
+          setTimeout(() => {
+            hide(dropdown);
+            root.addEventListener('click', clickListener);
+          }, 50);
+        }
+        document.addEventListener('mouseup', hide2);
+      };
+      document.addEventListener('mousedown', hide1);
+    }
+    root.addEventListener('click', clickListener);
 }
 
 


### PR DESCRIPTION
## Summary
Pure whitespace change. Project convention is 4-space indent for extension JS, but two files used tabs:

- `src/shared/utils.js` — 93 tab-indented lines, plus one misaligned line at :63 with a single leading space (likely a stray edit)
- `src/shared/analytics.js` — `recordEvent` function body

Converted leading tabs to 4 spaces; no functional change. Other findings from the survey were verified and skipped:

- `src/shared/https.js:38–39` — bare `console.log(req); console.log(res);` looks like debug-leftover at first glance, but the surrounding `reject('HTTP Error')` swallows the actual error context. The logs are the only place a developer can see what failed. Left as-is.

## Test plan
- [x] `npm test` in `tests/`: 168/170 pass (2 pre-existing todos), matches baseline
- [x] `npm test` in `server/`: 67/67 pass, matches baseline
- [x] `git diff --stat`: balanced 103/103 ins/del, confirming whitespace-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
