### PR TITLE
Fix intermittent settings reset: never persist tier-based demotions

### DIFF
--- a/docs/settings-reset-investigation.md
+++ b/docs/settings-reset-investigation.md
@@ -128,18 +128,15 @@ change.
 
 ## Narrow fix plan
 
-The bug-fix release contains two independent commits:
+The bug-fix release contains Phase 1 (commit A) only: the mechanical data-loss
+fix below. It is sufficient to fix the reported reset, is reviewable and
+revertible on its own, and does not add background lifecycle or permission
+surface. Background license renewal remains a separately reviewed follow-up;
+it improves continuity but is not required to preserve preferences.
 
-- **Commit A (Phase 1)** — the mechanical data-loss fix below. Reviewable and
-  revertible on its own; this is the actual bug fix.
-- **Commit B** — background license renewal (see its section below). A comfort
-  layer that removes the effective-behavior flicker at the 3-day boundary in
-  the common case. Separately revertible if service-worker/alarm behavior
-  proves quirky.
-
-Commit B is not a substitute for commit A: renewal cannot reliably win the
-race against the first page load after wake-from-sleep (the content script
-runs before any network round-trip completes), the license server's
+Background renewal is not a substitute for Phase 1: renewal cannot reliably
+win the race against the first page load after wake-from-sleep (the content
+script runs before any network round-trip completes), the license server's
 availability is independent of YouTube's (outages, DNS, or a user's
 adblock/privacy list can block `server.lawrencehook.com` while YouTube works —
 such a user would otherwise wipe every 3 days), the options page runs offline,
@@ -154,8 +151,8 @@ keeps the dangerous mechanism alive behind a condition every future caller
 must get right. Tier changes affect effective behavior only — stored
 preferences are never written by tier logic, unconditionally.
 
-The remaining sections after commit B are explicitly deferred ideas and should
-not be bundled into this release.
+The remaining follow-up sections are explicitly deferred and should not be
+bundled into this release.
 
 ### Phase 1 (commit A) — stop destroying stored preferences
 
@@ -240,10 +237,10 @@ Acceptance criteria:
 - Re-auth or re-upgrade restores previous premium choices without import
   (a page reload is acceptable in Phase 1).
 
-### Commit B — background license renewal (same release, separate commit)
+### Deferred follow-up — background license renewal
 
-Refresh the license token through a single background-owned refresh path when
-the token is near expiry (`LICENSE_REFRESH_THRESHOLD_MS` is already 24h), so
+Refresh the license token through a background-owned scheduled path when the
+token is near expiry (`LICENSE_REFRESH_THRESHOLD_MS` is already 24h), so
 renewal doesn't depend on the user opening the options page. Avoid direct
 content-script refreshes: content scripts run in all frames (both manifests
 set `all_frames: true`), which would duplicate requests — and the server's
@@ -258,24 +255,39 @@ Verified permission posture — no user-visible prompt:
   extension origin, which the server's CORS config already allows (the same
   reason the options page can fetch today).
 
-Implementation (~20-30 lines plus manifest edits):
+Implementation requirements:
 
-- Add `alarms` to both manifests; list the shared auth/license files in the
-  Firefox background `scripts` array and `importScripts` them in the Chrome
-  service worker.
-- On `runtime.onStartup` and a periodic alarm (every few hours), if a session
-  token exists, call the existing `License.checkLicense()` — it already
-  contains the refresh-if-expiring-within-24h logic and token storage; the
-  background adds only a schedule.
-- Deduplicate concurrent startup/alarm/user-triggered refreshes with one
-  in-flight promise.
+- Add `alarms` to both manifests. Load shared config, auth, and license scripts
+  before `background/events.js` in Firefox; import the same dependencies in
+  the Chrome service worker in dependency order.
+- Register alarm and runtime listeners synchronously. Whenever the background
+  context starts, check for the named periodic alarm and create it only when
+  absent; do not unconditionally recreate it and postpone its next firing.
+  This accounts for alarm persistence not being guaranteed across browser
+  restarts, extension updates, and browser implementations.
+- On `runtime.onStartup` and the periodic alarm (every few hours), call the
+  existing `License.checkLicense()` without forcing refresh. It already skips
+  the network when no session exists or the license is valid outside the 24h
+  refresh threshold, and stores a successfully refreshed token.
+- Deduplicate concurrent background startup/alarm refreshes with one in-flight
+  promise. Existing options-page checks execute in a separate context and are
+  not covered by that promise. Routing every manual check through background
+  messaging would be a larger refactor and is not required for this follow-up;
+  occasional overlap with a manual check is acceptable.
+- Treat failure outcomes precisely: transient network and non-`401` server
+  failures leave existing auth tokens untouched; `401` intentionally invokes
+  `Auth.signOut()` and removes auth tokens. Neither outcome may write any
+  preference key.
 - A bounded last-confirmed-entitlement/grace policy for transiently failed
   renewal stays deferred — with commit A in place, a failed renewal costs
   effective behavior only, never data.
 
-Commit B acceptance: paid users with a renewable session see no effective
-settings change at the 3-day license boundary, and overlapping triggers do
-not generate multiple renewal requests.
+Follow-up acceptance: paid users with a renewable session normally see no
+effective settings change at the 3-day license boundary; overlapping
+background triggers do not generate multiple renewal requests; and an actual
+background renewal succeeds in unpacked Chrome and Firefox without an
+additional host permission or CORS failure. Include wake-from-sleep coverage:
+an alarm may run late, but the resulting refresh must remain non-destructive.
 
 Optional server-side lever (zero extension change, no release needed):
 raising `LICENSE_TOKEN_LIFETIME_DAYS` (currently 3) shrinks boundary
@@ -323,15 +335,21 @@ Do not assert that Phase 1 provides immediate cross-context propagation or a
 stable user-selected pair when more than two preferences are stored; those are
 the two accepted limitations above. No server test change is required.
 
-Commit B tests (separate from commit A's):
+Background-renewal follow-up tests (not part of the bug-fix release):
 
-- Background refresh is single-flight when startup/alarm/manual triggers
-  overlap, and skips the network entirely when no session token exists or the
-  token isn't near expiry.
-- A failed background refresh writes nothing (preference snapshot unchanged;
-  existing tokens untouched).
+- Background refresh is single-flight when startup and alarm triggers overlap,
+  and skips the network entirely when no session token exists or the token
+  isn't near expiry. Manual options-page checks are independent.
+- A transient network or non-`401` server failure leaves auth tokens and the
+  preference snapshot unchanged.
+- A `401` removes the three auth keys as expected while leaving the preference
+  snapshot unchanged.
+- A named alarm is created when absent, retained without rescheduling when
+  present, and handled only when its name matches.
+- Smoke-test a real background renewal in unpacked Chrome and Firefox,
+  including a delayed alarm after wake-from-sleep.
 
-Deferred-work tests, not part of this release:
+Other deferred-work tests, not part of this release:
 
 - Auth-token-only changes re-derive settings in every already-open
   context without a reload.
@@ -339,10 +357,11 @@ Deferred-work tests, not part of this release:
 ## Appendix: storage-write inventory (audit)
 
 Every `browser.storage.local` write/remove in the extension is classified
-below. As of commit A, the background service worker does not write storage
-(commit B adds one: the refreshed `license_token` via the existing
-`License.checkLicense()` — an auth key, never a preference); the other
-extension pages outside this inventory are read-only with respect to settings.
+below. As of Phase 1, the background service worker does not write storage (the
+deferred renewal follow-up would add one auth-key write: a refreshed
+`license_token` via the existing `License.checkLicense()`, never a preference);
+the other extension pages outside this inventory are read-only with respect to
+settings.
 
 Destructive — removed by Phase 1:
 

--- a/docs/settings-reset-investigation.md
+++ b/docs/settings-reset-investigation.md
@@ -127,30 +127,19 @@ apply/render time, exactly as `clearAllPremium` already does:
   in its current form should have no remaining callers.)
 - Never persist a demotion for `error`/`offline` license results. Phase 1 may
   conservatively restrict effective behavior while entitlement is
-  indeterminate, but it must preserve preferences and re-derive immediately
-  after a successful refresh. Phase 2 defines continuity through that window.
+  indeterminate, but it must preserve preferences. Phase 2 defines continuity
+  through that window.
 
-Implementation constraint: the current destructive writes also happen to
-notify every open content script through `browser.storage.onChanged`. Once
-those writes are removed, auth-only changes (`license_token` or
-`session_token`) must explicitly trigger effective-settings reapplication.
-Otherwise an already-open YouTube page can retain premium behavior after
-sign-out/downgrade, and an already-open options page or content script can
-remain pruned after premium is restored.
-
-For Phase 1, factor one shared, pure derivation step such as
-`deriveEffectiveSettings(storedSettings, tier)` that returns a copy and never
-mutates its stored-settings input. Use it in both initializers and whenever
-the tier changes:
-
-- Content scripts should detect auth-token changes, read the current stored
-  preferences again, derive the new effective view, and reapply all premium
-  attributes/cache values.
-- The options page should do the same after `updatePremiumUI()` changes tier,
-  including after successful re-auth or upgrade.
-- Confirmed free, signed-in free, premium, and signed-out transitions must all
-  update already-open contexts without relying on preference writes as a
-  notification mechanism.
+Accepted limitation (keeps Phase 1 narrow): the current destructive writes
+also happened to notify already-open contexts through
+`browser.storage.onChanged`. With the writes removed, an open YouTube tab or
+options page reflects a confirmed tier change (sign-out, downgrade, re-upgrade)
+on its next page load rather than instantly. That staleness is cosmetic
+feature-gating, rare, and self-healing — acceptable for the data-loss fix. If
+the options page's own transient mismatch (rendered from clamped values, then
+tier confirmed a moment later) proves annoying, a one-line re-init after
+`updatePremiumUI()` changes tier is the cheap remedy. Full immediate
+cross-context re-derivation moves to Phase 3.
 
 The intended transition behavior is:
 
@@ -161,6 +150,9 @@ The intended transition behavior is:
 | Confirmed signed-in free | Unchanged | Apply the allowed slot budget |
 | Sign-out or session `401` | Unchanged | Disable premium behavior in memory |
 
+In Phase 1, "effective behavior" changes apply at the next initialization of
+each context (page load, popup open); immediate propagation is Phase 3.
+
 Acceptance criteria:
 
 - No auth, refresh, sign-out, or tier-transition path deletes or overwrites
@@ -168,9 +160,8 @@ Acceptance criteria:
 - Transient network failures cause no persistent changes.
 - Free-tier slot limits remain enforced in effective behavior and UI
   (direct toggles, chained effects, and import).
-- Already-open extension contexts immediately reflect confirmed tier changes.
-- Re-auth or re-upgrade restores previous premium choices without import or
-  a page reload.
+- Re-auth or re-upgrade restores previous premium choices without import
+  (a page reload is acceptable in Phase 1).
 
 ### Phase 2 — proactive license renewal
 
@@ -202,6 +193,11 @@ not generate multiple renewal requests.
 - Introduce an explicit indeterminate license state (pending / expired-but-
   renewable / offline / transient error) distinct from a confirmed free
   account, so callers can't accidentally collapse them.
+- Immediate cross-context tier propagation: factor a shared, pure
+  `deriveEffectiveSettings(storedSettings, tier)` (returns a copy, never
+  mutates its input) and re-run it in every open context when
+  `license_token`/`session_token` change, instead of relying on next page
+  load. This lifts Phase 1's accepted staleness limitation.
 - Consider a user-controlled list of selected free-slot feature IDs instead
   of first-two-by-list-order, keeping the premium preference set untouched.
 - If warranted, complete the desired-vs-effective settings separation:
@@ -221,10 +217,9 @@ token-expiry × settings-persistence lifecycle. Add:
   configuration unchanged.
 - Signed-in free user cannot activate a third slot via toggle, chained
   effect, or import.
-- Auth-token-only changes re-derive settings in every already-open context;
-  sign-out/downgrade disables effective premium behavior and re-auth/re-upgrade
-  restores the full desired configuration without a reload.
 - Each transition asserts a before/after snapshot of `browser.storage.local`
   proving preference keys did not change.
-- Background refresh is single-flight when startup/alarm/manual triggers or
-  multiple content frames overlap.
+- (Phase 2) Background refresh is single-flight when startup/alarm/manual
+  triggers or multiple content frames overlap.
+- (Phase 3) Auth-token-only changes re-derive settings in every already-open
+  context without a reload.

--- a/docs/settings-reset-investigation.md
+++ b/docs/settings-reset-investigation.md
@@ -64,9 +64,8 @@ Destructive write-back entry points:
 2. **Session expiry (30 days) → 401.** `checkLicense` signs the user out and
    `updatePremiumUI` calls `disableAllPremiumFeatures()`, persisting `false`
    for *every* premium feature (`license.js:58-63`,
-   `settings-menu.js:509-528`). Also hits signed-in free users — their slot
-   features get turned off — matching reports that the bug isn't
-   premium-only but seems limited to logged-in users.
+   `settings-menu.js:509-528`). This also provides a path affecting signed-in
+   free users: their selected slot features get turned off.
 3. **Explicit sign-out.** The sign-out button handler calls the same
    destructive helper (`settings-menu.js:711-726`).
 
@@ -74,7 +73,7 @@ All of this conflicts with the design already documented on
 `clearAllPremium()` (`src/shared/main.js:863`): entitlement enforcement is
 meant to be in-memory so stored premium preferences return when access
 returns. The slot-budget write-back introduced in #213 violates that
-principle, which is why reports are recent.
+principle and creates the reported regression.
 
 ## Why it appears intermittent
 
@@ -107,39 +106,48 @@ gather before/after storage diagnostics.
    `enforceSlotBudget(settings, 2)` → 4 settings returned as `false`
    write-backs. The 2 survivors are chosen by static list order.
 
-## Fix plan
+## Narrow fix plan
 
-Phased: Phase 1 is a small, shippable data-loss fix; later phases are
-incremental hardening. (Codex's fuller desired-vs-effective architecture is
-the end state; we get the safety win first without the refactor.)
+The bug-fix release should contain Phase 1 only. It is a small, mechanical
+data-loss fix. The later sections are explicitly deferred ideas and should not
+be bundled into the same change.
 
 ### Phase 1 — stop destroying stored preferences (minimal, ship first)
 
-Never persist tier-based demotions. Enforce tier in memory at
-apply/render time, exactly as `clearAllPremium` already does:
+Never persist tier-based demotions. Keep the existing control flow and enforce
+tier in memory at apply/render time, exactly as `clearAllPremium` already
+does. The behavioral patch is four concentrated call-site changes:
 
-- Drop the `enforceSlotBudget` write-backs in
-  `src/content-script/main.js` and `src/options/main.js` (enforce on the
-  in-memory copy only).
-- Make `pruneToSlotBudget()` and the `signedOut`/sign-out paths stop
-  routing through `updateSetting(..., false)` storage writes; update UI
-  state and the in-memory cache instead. (`disableAllPremiumFeatures()`
-  in its current form should have no remaining callers.)
-- Never persist a demotion for `error`/`offline` license results. Phase 1 may
-  conservatively restrict effective behavior while entitlement is
-  indeterminate, but it must preserve preferences. Phase 2 defines continuity
-  through that window.
+- In `src/content-script/main.js`, keep `enforceSlotBudget(settings, limit)`
+  but remove its `browser.storage.local.set(writeBack)` call.
+- In `src/options/main.js`, make the identical change: clamp the local
+  `settings` copy without writing the returned map to storage.
+- In `pruneToSlotBudget()`, retain the helper and UI updates but call
+  `updateSetting(id, false, { write: false })`.
+- In `disableAllPremiumFeatures()`, retain the helper and its callers but call
+  `updateSetting(id, false, { write: false })`.
+- Update the stale `enforceSlotBudget()` comment that currently instructs
+  callers to persist the returned map. No helper rename or redesign is needed.
+
+Do not add storage keys, background renewal, manifest permissions, messaging,
+new tier states, or a generalized desired-vs-effective settings layer in the
+Phase 1 patch.
+
+With those four behavioral changes, error/offline, `401`, explicit sign-out,
+content initialization, and options initialization all reuse their existing
+paths without overwriting preferences. Phase 1 may conservatively restrict
+effective behavior while entitlement is indeterminate, but it preserves the
+underlying preferences. The deferred renewal work defines continuity through
+that window.
 
 Accepted limitation (keeps Phase 1 narrow): the current destructive writes
 also happened to notify already-open contexts through
 `browser.storage.onChanged`. With the writes removed, an open YouTube tab or
 options page reflects a confirmed tier change (sign-out, downgrade, re-upgrade)
-on its next page load rather than instantly. That staleness is cosmetic
-feature-gating, rare, and self-healing — acceptable for the data-loss fix. If
-the options page's own transient mismatch (rendered from clamped values, then
-tier confirmed a moment later) proves annoying, a one-line re-init after
-`updatePremiumUI()` changes tier is the cheap remedy. Full immediate
-cross-context re-derivation moves to Phase 3.
+on its next page load rather than instantly. This is temporary effective-state
+staleness, including entitlement gating after sign-out or downgrade; it is not
+data loss, but it is not the ideal final behavior. Accepting it keeps the
+urgent patch narrow. Full immediate cross-context re-derivation is deferred.
 
 The intended transition behavior is:
 
@@ -151,7 +159,7 @@ The intended transition behavior is:
 | Sign-out or session `401` | Unchanged | Disable premium behavior in memory |
 
 In Phase 1, "effective behavior" changes apply at the next initialization of
-each context (page load, popup open); immediate propagation is Phase 3.
+each context (page load, popup open); immediate propagation is deferred.
 
 Acceptance criteria:
 
@@ -163,7 +171,7 @@ Acceptance criteria:
 - Re-auth or re-upgrade restores previous premium choices without import
   (a page reload is acceptable in Phase 1).
 
-### Phase 2 — proactive license renewal
+### Deferred follow-up — proactive license renewal
 
 Refresh the license token through a single background-owned refresh path when
 the token is near expiry (`LICENSE_REFRESH_THRESHOLD_MS` is already 24h), so
@@ -184,11 +192,11 @@ Implementation requirements include:
   transiently failed renewal rather than silently trusting an expired token
   forever.
 
-Phase 2 acceptance: paid users with a renewable session see no effective
-settings change at the 3-day license boundary, and multiple matching frames do
-not generate multiple renewal requests.
+Deferred renewal acceptance: paid users with a renewable session see no
+effective settings change at the 3-day license boundary, and multiple matching
+frames do not generate multiple renewal requests.
 
-### Phase 3 — explicit tier states and slot selection (optional hardening)
+### Deferred follow-up — tier states and slot selection
 
 - Introduce an explicit indeterminate license state (pending / expired-but-
   renewable / offline / transient error) distinct from a confirmed free
@@ -203,10 +211,11 @@ not generate multiple renewal requests.
 - If warranted, complete the desired-vs-effective settings separation:
   `stored preferences + confirmed entitlement -> effective settings`.
 
-## Tests to add
+## Tests
 
 The suite (currently 168 passing) has no coverage of the combined
-token-expiry × settings-persistence lifecycle. Add:
+token-expiry × settings-persistence lifecycle. Phase 1 should add focused
+regression coverage for its four behavioral changes:
 
 - Expired premium license + valid session ⇒ no `false` writes while renewal
   pending; successful renewal preserves all stored preferences.
@@ -219,7 +228,10 @@ token-expiry × settings-persistence lifecycle. Add:
   effect, or import.
 - Each transition asserts a before/after snapshot of `browser.storage.local`
   proving preference keys did not change.
-- (Phase 2) Background refresh is single-flight when startup/alarm/manual
+
+Deferred-work tests, not part of the Phase 1 patch:
+
+- Background refresh is single-flight when startup/alarm/manual
   triggers or multiple content frames overlap.
-- (Phase 3) Auth-token-only changes re-derive settings in every already-open
+- Auth-token-only changes re-derive settings in every already-open
   context without a reload.

--- a/docs/settings-reset-investigation.md
+++ b/docs/settings-reset-investigation.md
@@ -1,0 +1,173 @@
+# Settings reset: consolidated findings and fix plan
+
+Date: 2026-08-01
+Status: diagnosis confirmed by two independent investigations (Claude and
+Codex); this doc consolidates both and proposes a phased fix. No behavior
+change included.
+
+Supersedes the docs on branches `claude/investigate-settings-reset-bug` and
+`codex/investigation/settings-reset-findings`.
+
+## Symptom
+
+Users report that locally stored preferences intermittently "reset" to
+defaults, forcing them to re-import or re-select settings. Reported by at
+least one premium user; also plausible for signed-in free users. Reports
+began after PR #213 (`31b56a5`, "Free premium slots").
+
+## Root cause
+
+Tier is inferred synchronously from a locally cached license JWT that expires
+every **3 days** (`LICENSE_TOKEN_LIFETIME_DAYS`, `server/src/config.js:13`).
+When the cached tier looks like anything less than premium, the client
+**persists destructive writes** to `browser.storage.local`, permanently
+turning off premium settings. Temporary or indeterminate auth states
+(expired-but-renewable license, pending refresh, offline, transient server
+error) are treated as a confirmed free tier.
+
+Primary failure sequence for a premium user:
+
+1. More than two premium preferences are enabled; license token is valid for
+   3 days. Only the options page ever refreshes it (`refreshLicense`,
+   `src/options/settings-menu.js:450`). There is no background refresh, and
+   the content script never renews — it only reads.
+2. The user browses YouTube for 3+ days without opening the options page.
+   The license token expires; the 30-day session token remains valid.
+3. On the next YouTube page load, tier is computed as `free_signed_in`
+   (session present, license expired) and `enforceSlotBudget(settings, 2)`
+   returns a write-back map that **persists `false`** for every enabled
+   premium setting beyond the first two (by `PREMIUM_FEATURE_IDS` iteration
+   order — arbitrary, not user choice).
+4. A later successful license refresh restores premium, but the stored
+   preference values are already destroyed. The user must re-import.
+
+Destructive write-back entry points:
+
+- `src/content-script/main.js:125-134` — any matching YouTube page load.
+- `src/options/main.js:27-34` — options-page init, synchronously, *before*
+  the async `refreshLicense(true)` from `initAccountState`
+  (`settings-menu.js:487-507`) can confirm premium. Opening the settings page
+  on day 4 wipes settings even though the refresh would succeed moments
+  later.
+
+## Additional wipe paths (same underlying flaw)
+
+1. **Expired license + transient renewal failure.** `License.checkLicense()`
+   only falls back to the cached entitlement while the cached token is still
+   valid; once expired, a network/server failure returns
+   `{ isPremium: false, error: true }` (`src/shared/license.js:84-102`).
+   `updatePremiumUI()` doesn't distinguish this indeterminate result from a
+   confirmed free account — its non-premium branch calls
+   `pruneToSlotBudget()`, persisting the pruned values
+   (`settings-menu.js:519-547`).
+2. **Session expiry (30 days) → 401.** `checkLicense` signs the user out and
+   `updatePremiumUI` calls `disableAllPremiumFeatures()`, persisting `false`
+   for *every* premium feature (`license.js:58-63`,
+   `settings-menu.js:509-528`). Also hits signed-in free users — their slot
+   features get turned off — matching reports that the bug isn't
+   premium-only but seems limited to logged-in users.
+3. **Explicit sign-out.** The sign-out button handler calls the same
+   destructive helper (`settings-menu.js:711-726`).
+
+All of this conflicts with the design already documented on
+`clearAllPremium()` (`src/shared/main.js:863`): entitlement enforcement is
+meant to be in-memory so stored premium preferences return when access
+returns. The slot-budget write-back introduced in #213 violates that
+principle, which is why reports are recent.
+
+## Why it appears intermittent
+
+- Tied to the 3-day token boundary, not to any user action.
+- Opening the options page before expiry silently renews the token and
+  avoids the failure that time.
+- Network conditions around renewal change the outcome.
+- Users with ≤2 premium features enabled lose nothing to slot pruning.
+- Grandfathered tokens last 730 days
+  (`GRANDFATHERED_TOKEN_LIFETIME_DAYS`, `server/src/config.js:14`), so
+  lifetime accounts rarely hit the boundary — subscribers hit it every
+  3 days.
+- Most premium options default to `false`, so wiping them reads as a broad
+  "reset to defaults" even though free settings are intact.
+
+## Scope limitation
+
+No code path was found that clears *free* settings or all of storage. Init
+writes defaults only for missing keys; `Auth.signOut()` removes only the
+session token, license token, and email. If reports confirm free settings
+(e.g. `remove_homepage`) also reset, treat that as a separate issue and
+gather before/after storage diagnostics.
+
+## Local reproduction (no server needed)
+
+1. Craft an expired JWT payload with `premium: true`; keep any truthy
+   `session_token`.
+2. Enable six premium settings in a settings object.
+3. `License.getTierSync()` → `free_signed_in`;
+   `enforceSlotBudget(settings, 2)` → 4 settings returned as `false`
+   write-backs. The 2 survivors are chosen by static list order.
+
+## Fix plan
+
+Phased: Phase 1 is a small, shippable data-loss fix; later phases are
+incremental hardening. (Codex's fuller desired-vs-effective architecture is
+the end state; we get the safety win first without the refactor.)
+
+### Phase 1 — stop destroying stored preferences (minimal, ship first)
+
+Never persist tier-based demotions. Enforce tier in memory at
+apply/render time, exactly as `clearAllPremium` already does:
+
+- Drop the `enforceSlotBudget` write-backs in
+  `src/content-script/main.js` and `src/options/main.js` (enforce on the
+  in-memory copy only).
+- Make `pruneToSlotBudget()` and the `signedOut`/sign-out paths stop
+  routing through `updateSetting(..., false)` storage writes; update UI
+  state and the in-memory cache instead. (`disableAllPremiumFeatures()`
+  in its current form should have no remaining callers.)
+- Never demote on `error`/`offline` license results — only on an
+  authoritative "not premium" server response, and even then only in
+  effective behavior, not stored values.
+
+Acceptance criteria:
+
+- No auth, refresh, sign-out, or tier-transition path deletes or overwrites
+  stored preferences.
+- Paid users see no settings change at the 3-day license boundary.
+- Transient network failures cause no persistent changes.
+- Free-tier slot limits remain enforced in effective behavior and UI
+  (direct toggles, chained effects, and import).
+- Re-auth or re-upgrade restores previous premium choices without import.
+
+### Phase 2 — proactive license renewal
+
+Refresh the license token in the background (alarm in the background
+script, or content-script-triggered renewal when the token is near expiry
+— `LICENSE_REFRESH_THRESHOLD_MS` is already 24h), so renewal doesn't depend
+on the user opening the options page. While renewal is pending, use the
+last-known entitlement rather than demoting.
+
+### Phase 3 — explicit tier states and slot selection (optional hardening)
+
+- Introduce an explicit indeterminate license state (pending / expired-but-
+  renewable / offline / transient error) distinct from a confirmed free
+  account, so callers can't accidentally collapse them.
+- Consider a user-controlled list of selected free-slot feature IDs instead
+  of first-two-by-list-order, keeping the premium preference set untouched.
+- If warranted, complete the desired-vs-effective settings separation:
+  `stored preferences + confirmed entitlement -> effective settings`.
+
+## Tests to add
+
+The suite (currently 168 passing) has no coverage of the combined
+token-expiry × settings-persistence lifecycle. Add:
+
+- Expired premium license + valid session ⇒ no `false` writes while renewal
+  pending; successful renewal preserves all stored preferences.
+- Offline renewal after expiry ⇒ preferences preserved.
+- 401 ⇒ auth state removed, preferences preserved.
+- Explicit sign-out ⇒ preferences preserved.
+- Confirmed free account ⇒ effective two-slot behavior with stored premium
+  configuration unchanged.
+- Signed-in free user cannot activate a third slot via toggle, chained
+  effect, or import.
+- Re-upgrade restores the full desired configuration.

--- a/docs/settings-reset-investigation.md
+++ b/docs/settings-reset-investigation.md
@@ -97,6 +97,26 @@ session token, license token, and email. If reports confirm free settings
 (e.g. `remove_homepage`) also reset, treat that as a separate issue and
 gather before/after storage diagnostics.
 
+## Server and execution-context validation
+
+The complete server and manifest audit confirms that Phase 1 is extension-only:
+
+- `server/src/services/jwt.js` issues 30-day session tokens and regular 3-day
+  license tokens (730 days for grandfathered users), matching the client-side
+  expiry sequence above.
+- `server/src/routes/license.js` returns a new signed license after an
+  authenticated entitlement check, `401` comes from session verification, and
+  transient failures return non-success responses. The server never receives
+  or modifies extension preferences.
+- `src/background/events.js` only manages install behavior and the toolbar
+  icon. It does not refresh licenses or write settings.
+- The Chrome and Firefox manifests load the same settings code paths and run
+  the content script in all matching frames. No build step rewrites those
+  sources.
+
+Therefore Phase 1 requires no server, manifest, background, Stripe, or database
+change.
+
 ## Local reproduction (no server needed)
 
 1. Craft an expired JWT payload with `premium: true`; keep any truthy
@@ -146,8 +166,8 @@ Verified no-change-needed paths (full-source audit, see appendix):
   helpers' `false` writes pass through it unaffected.
 
 Do not add storage keys, background renewal, manifest permissions, messaging,
-new tier states, or a generalized desired-vs-effective settings layer in the
-Phase 1 patch.
+new tier states, server changes, or a generalized desired-vs-effective settings
+layer in the Phase 1 patch.
 
 With those four behavioral changes, error/offline, `401`, explicit sign-out,
 content initialization, and options initialization all reuse their existing
@@ -164,6 +184,14 @@ on its next page load rather than instantly. This is temporary effective-state
 staleness, including entitlement gating after sign-out or downgrade; it is not
 data loss, but it is not the ideal final behavior. Accepting it keeps the
 urgent patch narrow. Full immediate cross-context re-derivation is deferred.
+
+Second accepted limitation: when a signed-in free user has more than two
+premium preferences stored as `true`, initialization still chooses the first
+two by `PREMIUM_FEATURE_IDS` order. Selecting a different feature whose stored
+value is already `true` may not emit `storage.onChanged`, so another open
+context can remain stale until reload. The two-slot budget remains enforced and
+no preference is lost, but stable user-controlled slot selection requires
+separate state and is deferred rather than added to this patch.
 
 The intended transition behavior is:
 
@@ -233,17 +261,25 @@ The suite (currently 168 passing) has no coverage of the combined
 token-expiry × settings-persistence lifecycle. Phase 1 should add focused
 regression coverage for its four behavioral changes:
 
-- Expired premium license + valid session ⇒ no `false` writes while renewal
-  pending; successful renewal preserves all stored preferences.
-- Offline renewal after expiry ⇒ preferences preserved.
-- 401 ⇒ auth state removed, preferences preserved.
-- Explicit sign-out ⇒ preferences preserved.
-- Confirmed free account ⇒ effective two-slot behavior with stored premium
-  configuration unchanged.
-- Signed-in free user cannot activate a third slot via toggle, chained
-  effect, or import.
-- Each transition asserts a before/after snapshot of `browser.storage.local`
-  proving preference keys did not change.
+- Instrument the browser-storage mock to record writes and compare preference
+  keys separately from auth, migration, banner, and initialization keys.
+- Expired premium license + valid session: content and options initialization
+  clamp the effective view to two without changing any stored premium
+  preference. A later successful renewal still finds all preferences intact.
+- Offline renewal after expiry: effective behavior may be restricted, but the
+  stored preference snapshot is unchanged.
+- Session `401`: auth keys are removed as expected, while preference keys are
+  unchanged and the options cache/UI is disabled in memory.
+- Explicit sign-out: use the same preference-snapshot assertion.
+- Confirmed signed-in free: direct toggles, chained effects, and import never
+  produce more than two effective premium features; importing an over-budget
+  configuration preserves the imported raw values.
+- Exercise both `pruneToSlotBudget()` and `disableAllPremiumFeatures()` and
+  assert that their UI/cache updates produce no preference-key writes.
+
+Do not assert that Phase 1 provides immediate cross-context propagation or a
+stable user-selected pair when more than two preferences are stored; those are
+the two accepted limitations above. No server test change is required.
 
 Deferred-work tests, not part of the Phase 1 patch:
 
@@ -266,21 +302,28 @@ Destructive — removed by Phase 1:
   `pruneToSlotBudget()` and `disableAllPremiumFeatures()` — switched to
   `{ write: false }`.
 
-Benign — unchanged:
+System/maintenance writes — unchanged:
 
 - `content-script/main.js:122`, `options/main.js:22` — reveal-setting
   migration; fills missing keys only.
 - `content-script/main.js:145` — init defaults; missing keys only.
 - `content-script/main.js:736` — content-script `updateSetting`; callers only
-  touch free keys (reveal dismiss, `global_enable`, timed/schedule keys).
-- `options/main.js:403` — user-initiated toggles (deliberate writes).
+  touch free keys (reveal dismiss, `global_enable`, and timed state).
 - `options/main.js:671/676` — logging opt-in prompt keys.
-- `settings-menu.js:301` — import; writes what the user pasted.
 - `shared/banners.js:56` — per-banner dismissal key.
 - `shared/auth.js:55/109`, `shared/license.js:71` — auth/license token keys
   only; sign-out removes `session_token`, `license_token`, `user_email` and
   never touches settings.
 - `shared/https.js:27-28` — legacy donor-auth `user`/`login_token` keys;
   unrelated to current auth or settings.
+
+User-directed writes — unchanged:
+
+- `options/main.js:403` — direct toggles and option effects. An effect that
+  requests an over-budget premium `true` can be clamped to `false` and persist
+  that value; this requires an explicit user action and is outside the
+  intermittent auth/reset bug.
+- `settings-menu.js:301` — import; intentionally stores the pasted values
+  before applying an in-memory tier clamp.
 
 (Mixpanel's bundled queue uses `window.localStorage`, not extension storage.)

--- a/docs/settings-reset-investigation.md
+++ b/docs/settings-reset-investigation.md
@@ -141,9 +141,7 @@ Verified no-change-needed paths (full-source audit, see appendix):
   philosophy; leave it alone.
 - **Export** (`settings-menu.js:268`) reads `browser.storage.local` directly,
   not the clamped in-memory cache, so post-fix an export taken during an
-  entitlement lapse still contains the user's full preferences. (Pre-fix,
-  storage was already wiped by the time users exported — which is why reports
-  say "re-import".)
+  entitlement lapse still contains the user's full preferences.
 - `updateSetting`'s premium clamp only coerces `value === true`, so the two
   helpers' `false` writes pass through it unaffected.
 
@@ -256,10 +254,9 @@ Deferred-work tests, not part of the Phase 1 patch:
 
 ## Appendix: storage-write inventory (audit)
 
-Every `browser.storage.local` write/remove in the extension, classified. The
-extension has exactly three script contexts (content script, background
-service worker, options/popup page — both manifests); the background never
-writes storage.
+Every `browser.storage.local` write/remove in the extension is classified
+below. The background service worker does not write storage; the other
+extension pages outside this inventory are read-only with respect to settings.
 
 Destructive — removed by Phase 1:
 
@@ -283,7 +280,7 @@ Benign — unchanged:
 - `shared/auth.js:55/109`, `shared/license.js:71` — auth/license token keys
   only; sign-out removes `session_token`, `license_token`, `user_email` and
   never touches settings.
-- `shared/https.js:27-28` — legacy `user`/`login_token` keys (donors page);
+- `shared/https.js:27-28` — legacy donor-auth `user`/`login_token` keys;
   unrelated to current auth or settings.
 
 (Mixpanel's bundled queue uses `window.localStorage`, not extension storage.)

--- a/docs/settings-reset-investigation.md
+++ b/docs/settings-reset-investigation.md
@@ -2,8 +2,8 @@
 
 Date: 2026-08-01
 Status: diagnosis confirmed by two independent investigations (Claude and
-Codex); this doc consolidates both and proposes a phased fix. No behavior
-change included.
+Codex); this doc consolidates both and proposes a narrow fix plus deferred
+follow-ups. No behavior change included.
 
 Supersedes the docs on branches `claude/investigate-settings-reset-bug` and
 `codex/investigation/settings-reset-findings`.

--- a/docs/settings-reset-investigation.md
+++ b/docs/settings-reset-investigation.md
@@ -13,7 +13,8 @@ Supersedes the docs on branches `claude/investigate-settings-reset-bug` and
 Users report that locally stored preferences intermittently "reset" to
 defaults, forcing them to re-import or re-select settings. Reported by at
 least one premium user; also plausible for signed-in free users. Reports
-began after PR #213 (`31b56a5`, "Free premium slots").
+are consistent with the destructive write-back introduced by PR #213
+(`31b56a5`, "Free premium slots").
 
 ## Root cause
 
@@ -124,27 +125,77 @@ apply/render time, exactly as `clearAllPremium` already does:
   routing through `updateSetting(..., false)` storage writes; update UI
   state and the in-memory cache instead. (`disableAllPremiumFeatures()`
   in its current form should have no remaining callers.)
-- Never demote on `error`/`offline` license results — only on an
-  authoritative "not premium" server response, and even then only in
-  effective behavior, not stored values.
+- Never persist a demotion for `error`/`offline` license results. Phase 1 may
+  conservatively restrict effective behavior while entitlement is
+  indeterminate, but it must preserve preferences and re-derive immediately
+  after a successful refresh. Phase 2 defines continuity through that window.
+
+Implementation constraint: the current destructive writes also happen to
+notify every open content script through `browser.storage.onChanged`. Once
+those writes are removed, auth-only changes (`license_token` or
+`session_token`) must explicitly trigger effective-settings reapplication.
+Otherwise an already-open YouTube page can retain premium behavior after
+sign-out/downgrade, and an already-open options page or content script can
+remain pruned after premium is restored.
+
+For Phase 1, factor one shared, pure derivation step such as
+`deriveEffectiveSettings(storedSettings, tier)` that returns a copy and never
+mutates its stored-settings input. Use it in both initializers and whenever
+the tier changes:
+
+- Content scripts should detect auth-token changes, read the current stored
+  preferences again, derive the new effective view, and reapply all premium
+  attributes/cache values.
+- The options page should do the same after `updatePremiumUI()` changes tier,
+  including after successful re-auth or upgrade.
+- Confirmed free, signed-in free, premium, and signed-out transitions must all
+  update already-open contexts without relying on preference writes as a
+  notification mechanism.
+
+The intended transition behavior is:
+
+| Transition | Stored preferences | Effective behavior |
+| --- | --- | --- |
+| Refresh pending or transient error | Unchanged | Keep the current view when available; otherwise use a non-destructive fallback |
+| Confirmed premium | Unchanged | Reapply all stored preferences |
+| Confirmed signed-in free | Unchanged | Apply the allowed slot budget |
+| Sign-out or session `401` | Unchanged | Disable premium behavior in memory |
 
 Acceptance criteria:
 
 - No auth, refresh, sign-out, or tier-transition path deletes or overwrites
   stored preferences.
-- Paid users see no settings change at the 3-day license boundary.
 - Transient network failures cause no persistent changes.
 - Free-tier slot limits remain enforced in effective behavior and UI
   (direct toggles, chained effects, and import).
-- Re-auth or re-upgrade restores previous premium choices without import.
+- Already-open extension contexts immediately reflect confirmed tier changes.
+- Re-auth or re-upgrade restores previous premium choices without import or
+  a page reload.
 
 ### Phase 2 — proactive license renewal
 
-Refresh the license token in the background (alarm in the background
-script, or content-script-triggered renewal when the token is near expiry
-— `LICENSE_REFRESH_THRESHOLD_MS` is already 24h), so renewal doesn't depend
-on the user opening the options page. While renewal is pending, use the
-last-known entitlement rather than demoting.
+Refresh the license token through a single background-owned refresh path when
+the token is near expiry (`LICENSE_REFRESH_THRESHOLD_MS` is already 24h), so
+renewal doesn't depend on the user opening the options page. Avoid direct
+content-script refreshes: content scripts run in all frames, which could cause
+duplicate requests and cross-origin/permission problems. They should consume
+the resulting storage/message update instead.
+
+Implementation requirements include:
+
+- Add the required background alarm and premium-server host permissions to
+  both manifests.
+- Load or expose the auth/license dependencies in the Chrome service worker
+  and Firefox background context.
+- Deduplicate concurrent startup, alarm, and user-triggered refreshes with one
+  in-flight promise.
+- Define a bounded last-confirmed-entitlement/grace policy for pending or
+  transiently failed renewal rather than silently trusting an expired token
+  forever.
+
+Phase 2 acceptance: paid users with a renewable session see no effective
+settings change at the 3-day license boundary, and multiple matching frames do
+not generate multiple renewal requests.
 
 ### Phase 3 — explicit tier states and slot selection (optional hardening)
 
@@ -170,4 +221,10 @@ token-expiry × settings-persistence lifecycle. Add:
   configuration unchanged.
 - Signed-in free user cannot activate a third slot via toggle, chained
   effect, or import.
-- Re-upgrade restores the full desired configuration.
+- Auth-token-only changes re-derive settings in every already-open context;
+  sign-out/downgrade disables effective premium behavior and re-auth/re-upgrade
+  restores the full desired configuration without a reload.
+- Each transition asserts a before/after snapshot of `browser.storage.local`
+  proving preference keys did not change.
+- Background refresh is single-flight when startup/alarm/manual triggers or
+  multiple content frames overlap.

--- a/docs/settings-reset-investigation.md
+++ b/docs/settings-reset-investigation.md
@@ -128,11 +128,36 @@ change.
 
 ## Narrow fix plan
 
-The bug-fix release should contain Phase 1 only. It is a small, mechanical
-data-loss fix. The later sections are explicitly deferred ideas and should not
-be bundled into the same change.
+The bug-fix release contains two independent commits:
 
-### Phase 1 — stop destroying stored preferences (minimal, ship first)
+- **Commit A (Phase 1)** — the mechanical data-loss fix below. Reviewable and
+  revertible on its own; this is the actual bug fix.
+- **Commit B** — background license renewal (see its section below). A comfort
+  layer that removes the effective-behavior flicker at the 3-day boundary in
+  the common case. Separately revertible if service-worker/alarm behavior
+  proves quirky.
+
+Commit B is not a substitute for commit A: renewal cannot reliably win the
+race against the first page load after wake-from-sleep (the content script
+runs before any network round-trip completes), the license server's
+availability is independent of YouTube's (outages, DNS, or a user's
+adblock/privacy list can block `server.lawrencehook.com` while YouTube works —
+such a user would otherwise wipe every 3 days), the options page runs offline,
+and the sign-out/401 wipe paths have nothing to do with connectivity.
+
+Considered and rejected: gating the destructive writes on an authoritative
+server "not premium" response. The apply-time clamp must exist regardless
+(free tier and fresh installs have no server confirmation), which makes the
+persisted write redundant in every scenario; it would destroy the
+preserve-across-re-upgrade property exactly for churned subscribers; and it
+keeps the dangerous mechanism alive behind a condition every future caller
+must get right. Tier changes affect effective behavior only — stored
+preferences are never written by tier logic, unconditionally.
+
+The remaining sections after commit B are explicitly deferred ideas and should
+not be bundled into this release.
+
+### Phase 1 (commit A) — stop destroying stored preferences
 
 Never persist tier-based demotions. Keep the existing control flow and enforce
 tier in memory at apply/render time, exactly as `clearAllPremium` already
@@ -215,30 +240,47 @@ Acceptance criteria:
 - Re-auth or re-upgrade restores previous premium choices without import
   (a page reload is acceptable in Phase 1).
 
-### Deferred follow-up — proactive license renewal
+### Commit B — background license renewal (same release, separate commit)
 
 Refresh the license token through a single background-owned refresh path when
 the token is near expiry (`LICENSE_REFRESH_THRESHOLD_MS` is already 24h), so
 renewal doesn't depend on the user opening the options page. Avoid direct
-content-script refreshes: content scripts run in all frames, which could cause
-duplicate requests and cross-origin/permission problems. They should consume
-the resulting storage/message update instead.
+content-script refreshes: content scripts run in all frames (both manifests
+set `all_frames: true`), which would duplicate requests — and the server's
+CORS policy rejects page origins anyway (it allows only extension origins and
+localhost, `server/src/index.js:25-41`).
 
-Implementation requirements include:
+Verified permission posture — no user-visible prompt:
 
-- Add the required background alarm and premium-server host permissions to
-  both manifests.
-- Load or expose the auth/license dependencies in the Chrome service worker
-  and Firefox background context.
-- Deduplicate concurrent startup, alarm, and user-triggered refreshes with one
+- The `alarms` permission carries no warning string; Chrome and Firefox grant
+  it silently on update.
+- No `host_permissions` addition is needed: background fetches carry the
+  extension origin, which the server's CORS config already allows (the same
+  reason the options page can fetch today).
+
+Implementation (~20-30 lines plus manifest edits):
+
+- Add `alarms` to both manifests; list the shared auth/license files in the
+  Firefox background `scripts` array and `importScripts` them in the Chrome
+  service worker.
+- On `runtime.onStartup` and a periodic alarm (every few hours), if a session
+  token exists, call the existing `License.checkLicense()` — it already
+  contains the refresh-if-expiring-within-24h logic and token storage; the
+  background adds only a schedule.
+- Deduplicate concurrent startup/alarm/user-triggered refreshes with one
   in-flight promise.
-- Define a bounded last-confirmed-entitlement/grace policy for pending or
-  transiently failed renewal rather than silently trusting an expired token
-  forever.
+- A bounded last-confirmed-entitlement/grace policy for transiently failed
+  renewal stays deferred — with commit A in place, a failed renewal costs
+  effective behavior only, never data.
 
-Deferred renewal acceptance: paid users with a renewable session see no
-effective settings change at the 3-day license boundary, and multiple matching
-frames do not generate multiple renewal requests.
+Commit B acceptance: paid users with a renewable session see no effective
+settings change at the 3-day license boundary, and overlapping triggers do
+not generate multiple renewal requests.
+
+Optional server-side lever (zero extension change, no release needed):
+raising `LICENSE_TOKEN_LIFETIME_DAYS` (currently 3) shrinks boundary
+frequency for all users of existing versions immediately. Tradeoff: the
+lifetime is also how long a canceled subscription keeps premium working.
 
 ### Deferred follow-up — tier states and slot selection
 
@@ -281,17 +323,25 @@ Do not assert that Phase 1 provides immediate cross-context propagation or a
 stable user-selected pair when more than two preferences are stored; those are
 the two accepted limitations above. No server test change is required.
 
-Deferred-work tests, not part of the Phase 1 patch:
+Commit B tests (separate from commit A's):
 
-- Background refresh is single-flight when startup/alarm/manual
-  triggers or multiple content frames overlap.
+- Background refresh is single-flight when startup/alarm/manual triggers
+  overlap, and skips the network entirely when no session token exists or the
+  token isn't near expiry.
+- A failed background refresh writes nothing (preference snapshot unchanged;
+  existing tokens untouched).
+
+Deferred-work tests, not part of this release:
+
 - Auth-token-only changes re-derive settings in every already-open
   context without a reload.
 
 ## Appendix: storage-write inventory (audit)
 
 Every `browser.storage.local` write/remove in the extension is classified
-below. The background service worker does not write storage; the other
+below. As of commit A, the background service worker does not write storage
+(commit B adds one: the refreshed `license_token` via the existing
+`License.checkLicense()` — an auth key, never a preference); the other
 extension pages outside this inventory are read-only with respect to settings.
 
 Destructive — removed by Phase 1:

--- a/docs/settings-reset-investigation.md
+++ b/docs/settings-reset-investigation.md
@@ -123,11 +123,29 @@ does. The behavioral patch is four concentrated call-site changes:
 - In `src/options/main.js`, make the identical change: clamp the local
   `settings` copy without writing the returned map to storage.
 - In `pruneToSlotBudget()`, retain the helper and UI updates but call
-  `updateSetting(id, false, { write: false })`.
+  `updateSetting(id, false, { write: false })`. Keep `enforceSlotBudget`'s
+  return value — this helper still consumes it (the two init sites no longer
+  will; drop their unused `writeBack` variable, keeping the call for its
+  in-memory mutation).
 - In `disableAllPremiumFeatures()`, retain the helper and its callers but call
   `updateSetting(id, false, { write: false })`.
 - Update the stale `enforceSlotBudget()` comment that currently instructs
   callers to persist the returned map. No helper rename or redesign is needed.
+
+Verified no-change-needed paths (full-source audit, see appendix):
+
+- **Import** (`settings-menu.js:301`) persists the pasted settings verbatim —
+  including premium prefs — then `updateSettings()` applies them through
+  `updateSetting(..., { write: false })`, whose tier clamp keeps effective
+  behavior within budget. That already matches the stored-vs-effective
+  philosophy; leave it alone.
+- **Export** (`settings-menu.js:268`) reads `browser.storage.local` directly,
+  not the clamped in-memory cache, so post-fix an export taken during an
+  entitlement lapse still contains the user's full preferences. (Pre-fix,
+  storage was already wiped by the time users exported — which is why reports
+  say "re-import".)
+- `updateSetting`'s premium clamp only coerces `value === true`, so the two
+  helpers' `false` writes pass through it unaffected.
 
 Do not add storage keys, background renewal, manifest permissions, messaging,
 new tier states, or a generalized desired-vs-effective settings layer in the
@@ -235,3 +253,37 @@ Deferred-work tests, not part of the Phase 1 patch:
   triggers or multiple content frames overlap.
 - Auth-token-only changes re-derive settings in every already-open
   context without a reload.
+
+## Appendix: storage-write inventory (audit)
+
+Every `browser.storage.local` write/remove in the extension, classified. The
+extension has exactly three script contexts (content script, background
+service worker, options/popup page — both manifests); the background never
+writes storage.
+
+Destructive — removed by Phase 1:
+
+- `content-script/main.js:133` — slot-budget write-back on page load.
+- `options/main.js:33` — slot-budget write-back on options init.
+- `options/main.js:403` via `updateSetting(write: true)` from
+  `pruneToSlotBudget()` and `disableAllPremiumFeatures()` — switched to
+  `{ write: false }`.
+
+Benign — unchanged:
+
+- `content-script/main.js:122`, `options/main.js:22` — reveal-setting
+  migration; fills missing keys only.
+- `content-script/main.js:145` — init defaults; missing keys only.
+- `content-script/main.js:736` — content-script `updateSetting`; callers only
+  touch free keys (reveal dismiss, `global_enable`, timed/schedule keys).
+- `options/main.js:403` — user-initiated toggles (deliberate writes).
+- `options/main.js:671/676` — logging opt-in prompt keys.
+- `settings-menu.js:301` — import; writes what the user pasted.
+- `shared/banners.js:56` — per-banner dismissal key.
+- `shared/auth.js:55/109`, `shared/license.js:71` — auth/license token keys
+  only; sign-out removes `session_token`, `license_token`, `user_email` and
+  never touches settings.
+- `shared/https.js:27-28` — legacy `user`/`login_token` keys (donors page);
+  unrelated to current auth or settings.
+
+(Mixpanel's bundled queue uses `window.localStorage`, not extension storage.)

--- a/docs/settings-reset-investigation.md
+++ b/docs/settings-reset-investigation.md
@@ -1,11 +1,16 @@
 # Settings reset: consolidated findings and fix plan
 
 Date: 2026-08-01
-Status: diagnosis confirmed by two independent investigations (Claude and
-Codex); this doc consolidates both and proposes a narrow fix plus deferred
-follow-ups. No behavior change included.
+Status: **Phase 1 implemented** (PR #223) — the four call-site changes below,
+plus regression coverage in
+`tests/content-script/settings-persistence.test.js`. This doc remains as the
+diagnosis, audit, and decision record; the "Deferred follow-up" sections
+(background license renewal, tier states, slot selection) are still pending
+and spec'd here for future releases.
 
-Supersedes the docs on branches `claude/investigate-settings-reset-bug` and
+Diagnosis was confirmed by two independent investigations (Claude and Codex);
+this doc consolidates both and supersedes the docs on branches
+`claude/investigate-settings-reset-bug` and
 `codex/investigation/settings-reset-findings`.
 
 ## Symptom

--- a/docs/settings-reset-investigation.md
+++ b/docs/settings-reset-investigation.md
@@ -132,7 +132,10 @@ The bug-fix release contains Phase 1 (commit A) only: the mechanical data-loss
 fix below. It is sufficient to fix the reported reset, is reviewable and
 revertible on its own, and does not add background lifecycle or permission
 surface. Background license renewal remains a separately reviewed follow-up;
-it improves continuity but is not required to preserve preferences.
+it improves continuity but is not required to preserve preferences. Keeping
+renewal out also keeps the manifests untouched: a manifest/permission change
+(even the warning-free `alarms`) can draw extra store-review scrutiny, and the
+urgent fix's release should not be coupled to that.
 
 Background renewal is not a substitute for Phase 1: renewal cannot reliably
 win the race against the first page load after wake-from-sleep (the content

--- a/src/chrome_manifest.json
+++ b/src/chrome_manifest.json
@@ -3,7 +3,7 @@
   "description": "Spend less time on YouTube. Customize YouTube's user interface to be less engaging.",
   "homepage_url": "https://github.com/lawrencehook/remove-youtube-suggestions",
   "manifest_version": 3,
-  "version": "4.3.81",
+  "version": "4.3.82",
 
   "icons": {
     "16": "/images/16.png",

--- a/src/content-script/main.js
+++ b/src/content-script/main.js
@@ -129,8 +129,7 @@ browser.storage.local.get(settings => {
   if (tier === TIER.FREE) {
     clearAllPremium(settings);
   } else if (tier === TIER.FREE_SIGNED_IN) {
-    const writeBack = enforceSlotBudget(settings, PREMIUM_CONFIG.FREE_PREMIUM_SLOTS);
-    if (Object.keys(writeBack).length) browser.storage.local.set(writeBack);
+    enforceSlotBudget(settings, PREMIUM_CONFIG.FREE_PREMIUM_SLOTS);
   }
 
   Object.entries({ ...DEFAULT_SETTINGS, ...settings}).forEach(([ id, value ]) => {

--- a/src/firefox_manifest.json
+++ b/src/firefox_manifest.json
@@ -3,7 +3,7 @@
   "description": "Spend less time on YouTube. Customize YouTube's user interface to be less engaging.",
   "homepage_url": "https://github.com/lawrencehook/remove-youtube-suggestions",
   "manifest_version": 2,
-  "version": "4.3.81",
+  "version": "4.3.82",
 
   "icons": {
     "16": "/images/16.png",

--- a/src/options/main.js
+++ b/src/options/main.js
@@ -29,8 +29,7 @@ document.addEventListener("DOMContentLoaded", () => {
     if (tier === TIER.FREE) {
       clearAllPremium(settings);
     } else if (tier === TIER.FREE_SIGNED_IN) {
-      const writeBack = enforceSlotBudget(settings, PREMIUM_CONFIG.FREE_PREMIUM_SLOTS);
-      if (Object.keys(writeBack).length) browser.storage.local.set(writeBack);
+      enforceSlotBudget(settings, PREMIUM_CONFIG.FREE_PREMIUM_SLOTS);
     }
 
     const headerSettings = Object.entries(OTHER_SETTINGS).reduce((acc, [id, value]) => {

--- a/src/options/settings-menu.js
+++ b/src/options/settings-menu.js
@@ -509,16 +509,17 @@ initAccountState();
 // Turn off every premium feature (including menu-level ones like schedule/password).
 // Used when dropping to the `free` tier via sign-out or license revocation.
 function disableAllPremiumFeatures() {
-  PREMIUM_FEATURE_IDS.forEach(id => updateSetting(id, false));
+  PREMIUM_FEATURE_IDS.forEach(id => updateSetting(id, false, { write: false }));
 }
 
 // When transitioning into `free_signed_in` (e.g. subscription lapsed while the
 // options page is open), disable any premium features beyond FREE_PREMIUM_SLOTS
 // so current state matches the new tier. Reuses the shared enforceSlotBudget
-// helper and routes writes through updateSetting so the full UI stays in sync.
+// helper and routes updates through updateSetting so the full UI stays in
+// sync — in memory only; stored preferences are never written by tier logic.
 function pruneToSlotBudget() {
   const overBudget = enforceSlotBudget(cache, PREMIUM_CONFIG.FREE_PREMIUM_SLOTS);
-  Object.keys(overBudget).forEach(id => updateSetting(id, false));
+  Object.keys(overBudget).forEach(id => updateSetting(id, false, { write: false }));
 }
 
 function updatePremiumUI(licenseData) {

--- a/src/shared/main.js
+++ b/src/shared/main.js
@@ -865,9 +865,10 @@ function clearAllPremium(settings) {
 }
 
 // Mutates `settings` so at most `slotLimit` premium features stay true (by
-// iteration order). Returns a write-back map of the cleared settings — callers
-// should persist these to storage so over-budget premium settings don't
-// re-surface on the next load.
+// iteration order). Returns a map of the cleared settings for callers that
+// need to sync UI state. In-memory only, like clearAllPremium — callers must
+// never persist the cleared values; stored preferences stay intact so the
+// user's premium state returns when access returns.
 function enforceSlotBudget(settings, slotLimit) {
   const writeBack = {};
   let kept = 0;

--- a/tests/content-script/settings-persistence.test.js
+++ b/tests/content-script/settings-persistence.test.js
@@ -1,0 +1,143 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert');
+const { loadSourceFile, resetStorage, setStorageData, getStorageData } = require('../setup');
+
+/**
+ * Regression tests for the intermittent settings-reset bug
+ * (docs/settings-reset-investigation.md).
+ *
+ * Loads the real content script against the storage mock, seeded with the
+ * exact state of an affected user, and asserts that initialization never
+ * overwrites stored preferences. Entitlement enforcement must be in-memory
+ * only (the effective view may be clamped; storage may not change).
+ */
+
+// Six premium preferences, listed in PREMIUM_FEATURE_IDS order so the
+// buggy slot-budget write-back predictably keeps the first two and
+// persists `false` over the last four.
+const PREMIUM_PREFS = [
+  'remove_video_thumbnails',
+  'blur_video_thumbnails',
+  'shrink_video_thumbnails',
+  'disable_play_on_hover',
+  'remove_header',
+  'remove_chat',
+];
+
+// Expired JWT with premium: true. The client decodes without verifying the
+// signature, so a fake signature is fine.
+function expiredPremiumJWT() {
+  const encode = obj => Buffer.from(JSON.stringify(obj)).toString('base64url');
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const payload = {
+    email: 'repro@example.com',
+    premium: true,
+    grandfathered: false,
+    iat: now - 4 * 24 * 60 * 60, // issued 4 days ago
+    exp: now - 24 * 60 * 60,     // expired 1 day ago
+  };
+  return `${encode(header)}.${encode(payload)}.fake-signature`;
+}
+
+// Minimal DOM stubs for the content script. A watch-page URL keeps the
+// homepage/redirect branches quiet, and document.hidden stops the dynamic
+// settings polling loop after its first pass.
+function domStubs() {
+  const attrs = {};
+  const documentElement = {
+    setAttribute: (k, v) => { attrs[k] = String(v); },
+    getAttribute: k => (k in attrs ? attrs[k] : null),
+    removeAttribute: k => { delete attrs[k]; },
+    hasAttribute: k => k in attrs,
+    toggleAttribute: () => {},
+  };
+  return {
+    document: {
+      documentElement,
+      hidden: true,
+      addEventListener: () => {},
+      querySelector: () => null,
+      querySelectorAll: () => [],
+    },
+    location: { href: 'https://www.youtube.com/watch?v=repro' },
+    window: {},
+  };
+}
+
+// Load the real content script and let its async storage callbacks settle.
+// Dependencies are loaded individually and their globals passed through,
+// because the content script references them at top level (loadSourceFiles
+// only exposes cross-file globals after all files have run).
+async function runContentScriptInit() {
+  const stubs = domStubs();
+  const utils = loadSourceFile('shared/utils.js', stubs);
+  const config = loadSourceFile('shared/config.js');
+  const shared = loadSourceFile('shared/main.js');
+
+  loadSourceFile('content-script/main.js', {
+    ...stubs,
+    qs: utils.qs,
+    qsa: utils.qsa,
+    resultsPageRegex: utils.resultsPageRegex,
+    homepageRegex: utils.homepageRegex,
+    shortsRegex: utils.shortsRegex,
+    videoPageRegex: utils.videoPageRegex,
+    channelRegex: utils.channelRegex,
+    subsRegex: utils.subsRegex,
+    checkSchedule: utils.checkSchedule,
+    PREMIUM_CONFIG: config.PREMIUM_CONFIG,
+    TIER: config.TIER,
+    DEFAULT_SETTINGS: shared.DEFAULT_SETTINGS,
+    migrateRevealSettings: shared.migrateRevealSettings,
+    clearAllPremium: shared.clearAllPremium,
+    enforceSlotBudget: shared.enforceSlotBudget,
+    countActivePremium: shared.countActivePremium,
+    PREMIUM_FEATURE_ID_SET: shared.PREMIUM_FEATURE_ID_SET,
+    PREMIUM_FEATURE_IDS: shared.PREMIUM_FEATURE_IDS,
+  });
+  await new Promise(resolve => setTimeout(resolve, 20));
+}
+
+describe('Settings persistence across content-script initialization', () => {
+  beforeEach(() => {
+    resetStorage();
+  });
+
+  it('expired premium license + valid session: init must not overwrite stored premium preferences', async () => {
+    // Day-4 premium user: session still valid, license token expired,
+    // more than two premium preferences enabled.
+    const seed = { session_token: 'valid-session-token', license_token: expiredPremiumJWT() };
+    PREMIUM_PREFS.forEach(id => { seed[id] = true; });
+    setStorageData(seed);
+
+    await runContentScriptInit();
+
+    const after = getStorageData();
+    PREMIUM_PREFS.forEach(id => {
+      assert.strictEqual(
+        after[id], true,
+        `${id} was overwritten in storage by tier enforcement — ` +
+        'entitlement must clamp the effective view only, never stored preferences'
+      );
+    });
+  });
+
+  it('signed out (no tokens): init must not overwrite stored premium preferences', async () => {
+    // Free-tier user with premium preferences left over from a previous
+    // subscription. clearAllPremium must stay in-memory only.
+    const seed = {};
+    PREMIUM_PREFS.forEach(id => { seed[id] = true; });
+    setStorageData(seed);
+
+    await runContentScriptInit();
+
+    const after = getStorageData();
+    PREMIUM_PREFS.forEach(id => {
+      assert.strictEqual(
+        after[id], true,
+        `${id} was overwritten in storage during free-tier init`
+      );
+    });
+  });
+});

--- a/tests/content-script/settings-persistence.test.js
+++ b/tests/content-script/settings-persistence.test.js
@@ -65,11 +65,11 @@ function domStubs() {
   };
 }
 
-// Load the real content script and let its async storage callbacks settle.
+// Load the real content script and return its effective DOM settings.
 // Dependencies are loaded individually and their globals passed through,
 // because the content script references them at top level (loadSourceFiles
 // only exposes cross-file globals after all files have run).
-async function runContentScriptInit() {
+function runContentScriptInit() {
   const stubs = domStubs();
   const utils = loadSourceFile('shared/utils.js', stubs);
   const config = loadSourceFile('shared/config.js');
@@ -96,7 +96,10 @@ async function runContentScriptInit() {
     PREMIUM_FEATURE_ID_SET: shared.PREMIUM_FEATURE_ID_SET,
     PREMIUM_FEATURE_IDS: shared.PREMIUM_FEATURE_IDS,
   });
-  await new Promise(resolve => setTimeout(resolve, 20));
+  return {
+    effectiveSettings: stubs.document.documentElement,
+    freePremiumSlots: config.PREMIUM_CONFIG.FREE_PREMIUM_SLOTS,
+  };
 }
 
 describe('Settings persistence across content-script initialization', () => {
@@ -104,14 +107,21 @@ describe('Settings persistence across content-script initialization', () => {
     resetStorage();
   });
 
-  it('expired premium license + valid session: init must not overwrite stored premium preferences', async () => {
+  it('expired premium license + valid session: init must not overwrite stored premium preferences', () => {
     // Day-4 premium user: session still valid, license token expired,
     // more than two premium preferences enabled.
     const seed = { session_token: 'valid-session-token', license_token: expiredPremiumJWT() };
     PREMIUM_PREFS.forEach(id => { seed[id] = true; });
     setStorageData(seed);
 
-    await runContentScriptInit();
+    const { effectiveSettings, freePremiumSlots } = runContentScriptInit();
+
+    PREMIUM_PREFS.forEach((id, index) => {
+      assert.strictEqual(
+        effectiveSettings.getAttribute(id), String(index < freePremiumSlots),
+        `${id} did not reflect the signed-in free slot budget`
+      );
+    });
 
     const after = getStorageData();
     PREMIUM_PREFS.forEach(id => {
@@ -123,14 +133,21 @@ describe('Settings persistence across content-script initialization', () => {
     });
   });
 
-  it('signed out (no tokens): init must not overwrite stored premium preferences', async () => {
+  it('signed out (no tokens): init must not overwrite stored premium preferences', () => {
     // Free-tier user with premium preferences left over from a previous
     // subscription. clearAllPremium must stay in-memory only.
     const seed = {};
     PREMIUM_PREFS.forEach(id => { seed[id] = true; });
     setStorageData(seed);
 
-    await runContentScriptInit();
+    const { effectiveSettings } = runContentScriptInit();
+
+    PREMIUM_PREFS.forEach(id => {
+      assert.strictEqual(
+        effectiveSettings.getAttribute(id), 'false',
+        `${id} remained effectively enabled during free-tier init`
+      );
+    });
 
     const after = getStorageData();
     PREMIUM_PREFS.forEach(id => {


### PR DESCRIPTION
## Summary

Fixes the intermittent "settings reset to defaults" bug reported by premium and signed-in free users.

**Root cause:** tier is inferred from a locally cached license JWT that expires every 3 days, and when the cached tier looked like anything less than premium, the client persisted destructive writes to `browser.storage.local` — permanently turning off premium settings. Temporary auth states (expired-but-renewable token, offline, transient server error, session 401, sign-out) were treated as a confirmed free tier. Introduced by #213.

**The fix (10 lines across 4 files):** tier enforcement is now in-memory only, matching `clearAllPremium`'s documented design. Features may *behave* clamped while entitlement is unconfirmed, but stored preferences are never written by tier logic — so everything reactivates once the license refreshes, with no re-import.

- `content-script/main.js`, `options/main.js`: drop the `enforceSlotBudget` storage write-back; keep the in-memory clamp.
- `settings-menu.js`: `pruneToSlotBudget()` / `disableAllPremiumFeatures()` route through `updateSetting(..., { write: false })`.
- `shared/main.js`: comment updated to document the in-memory-only contract.

## Also in this PR

- `docs/settings-reset-investigation.md` — consolidated diagnosis (two independent investigations), full storage-write audit, decision records, accepted limitations, and deferred follow-ups (background license renewal, slot selection, cross-context propagation).
- `tests/content-script/settings-persistence.test.js` — regression test that loads the real content script against the storage mock with an expired premium JWT + valid session. Committed failing first (reproducing the wipe), green after the fix; also asserts the in-memory slot budget still enforces.

## Test plan

- [x] Full suite: 170 pass / 0 fail (was 168 pass + 1 intentional fail before the fix)
- [x] Manual repro (Chrome, unpacked): seeded expired-premium state, loaded YouTube — all six premium prefs survive in storage; popup 401 path signs out without wiping

Known accepted limitations (documented in the plan doc): already-open tabs reflect a confirmed tier change on next page load, and the free-tier slot pair remains first-two-by-list-order. Already-wiped users need one final re-import — the fix prevents future loss, it cannot restore past loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
