### PR TITLE
Upgrade supertest to v7

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,7 +19,7 @@
         "uuid": "^14.0.0"
       },
       "devDependencies": {
-        "supertest": "^6.3.4"
+        "supertest": "^7.2.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -1927,16 +1927,18 @@
       }
     },
     "node_modules/formidable": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
-      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.2",
         "dezalgo": "^1.0.4",
-        "once": "^1.4.0",
-        "qs": "^6.11.0"
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
@@ -2842,26 +2844,24 @@
       "license": "MIT"
     },
     "node_modules/superagent": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
-      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
-      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "component-emitter": "^1.3.0",
+        "component-emitter": "^1.3.1",
         "cookiejar": "^2.1.4",
-        "debug": "^4.3.4",
+        "debug": "^4.3.7",
         "fast-safe-stringify": "^2.1.1",
-        "form-data": "^4.0.0",
-        "formidable": "^2.1.2",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
         "methods": "^1.1.2",
         "mime": "2.6.0",
-        "qs": "^6.11.0",
-        "semver": "^7.3.8"
+        "qs": "^6.14.1"
       },
       "engines": {
-        "node": ">=6.4.0 <13 || >=14"
+        "node": ">=14.18.0"
       }
     },
     "node_modules/superagent/node_modules/debug": {
@@ -2903,18 +2903,28 @@
       "license": "MIT"
     },
     "node_modules/supertest": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
-      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
-      "deprecated": "Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "cookie-signature": "^1.2.2",
         "methods": "^1.1.2",
-        "superagent": "^8.1.2"
+        "superagent": "^10.3.0"
       },
       "engines": {
-        "node": ">=6.4.0"
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/tar-fs": {

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
     "uuid": "^14.0.0"
   },
   "devDependencies": {
-    "supertest": "^6.3.4"
+    "supertest": "^7.2.2"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
Upgrades supertest 6.3.4 -> 7.2.2 (dev dependency; pulls superagent v10), clearing the deprecated-package warnings from npm install. 67/67 server tests pass locally; CI validates on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)