### PR TITLE
Raise license token lifetime from 3 to 14 days

### DIFF
--- a/server/src/config.js
+++ b/server/src/config.js
@@ -10,7 +10,10 @@ module.exports = {
   // JWT
   get JWT_SECRET() { return process.env.JWT_SECRET; },
   SESSION_TOKEN_LIFETIME_DAYS: 30,
-  LICENSE_TOKEN_LIFETIME_DAYS: 3,
+  // 14 days: reduces how often clients hit the expiry boundary (the
+  // settings-reset bug trigger for pre-4.3.82 versions) at the cost of a
+  // canceled subscription keeping premium until its token expires.
+  LICENSE_TOKEN_LIFETIME_DAYS: 14,
   GRANDFATHERED_TOKEN_LIFETIME_DAYS: 730, // 2 years
 
   // Timing


### PR DESCRIPTION
The server-side lever from docs/settings-reset-investigation.md: reduces expiry-boundary frequency ~5x for all users — including those still on pre-4.3.82 extension versions where the boundary triggered the settings wipe. Tradeoff: a canceled subscription keeps premium until its token expires (up to 14 days). One-line change; no test pins the value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)